### PR TITLE
BSS-104

### DIFF
--- a/BlockchainSdk/Common/WalletManager.swift
+++ b/BlockchainSdk/Common/WalletManager.swift
@@ -158,7 +158,7 @@ public class WalletManager {
     }
     
     private func validateAmountValue(_ amount: Amount) -> Bool {
-        return amount.value > 0
+        return amount.value >= 0
     }
     
     private func validateAmountTotal(_ amount: Amount) -> Bool {


### PR DESCRIPTION
Update amount validation rule to allow sending 0 value ethereum transaction. This can be used in transactions from dApp (OpenSea)