### PR TITLE
IOS-1616 Using `.share` to create a shared publisher

### DIFF
--- a/BlockchainSdk/WalletManagers/Solana/SolanaSdk+.swift
+++ b/BlockchainSdk/WalletManagers/Solana/SolanaSdk+.swift
@@ -31,6 +31,7 @@ extension Api {
                 }
             }
         }
+        .share()
         .eraseToAnyPublisher()
     }
     
@@ -59,6 +60,7 @@ extension Api {
                 }
             }
         }
+        .share()
         .eraseToAnyPublisher()
     }
     
@@ -80,6 +82,7 @@ extension Api {
                 }
             }
         }
+        .share()
         .eraseToAnyPublisher()
     }
     
@@ -108,6 +111,7 @@ extension Api {
                 }
             }
         }
+        .share()
         .eraseToAnyPublisher()
     }
     
@@ -129,6 +133,7 @@ extension Api {
                 }
             }
         }
+        .share()
         .eraseToAnyPublisher()
     }
 }
@@ -152,6 +157,7 @@ extension Action {
                 }
             }
         }
+        .share()
         .eraseToAnyPublisher()
     }
     
@@ -183,6 +189,7 @@ extension Action {
                 }
             }
         }
+        .share()
         .eraseToAnyPublisher()
     }
     
@@ -220,6 +227,7 @@ extension Action {
                 }
             }
         }
+        .share()
         .eraseToAnyPublisher()
     }
 }


### PR DESCRIPTION
Почему-то замыкание в Future вызывалось второй раз после вызова `promise(.failure(error))` в `sendSol`. Subscriber этого пайплайна нигде не копируется.