### PR TITLE
IOS-2294 Exposing the rounding mode for Amount formatting

### DIFF
--- a/BlockchainSdk/Common/Amount.swift
+++ b/BlockchainSdk/Common/Amount.swift
@@ -88,7 +88,7 @@ public struct Amount: CustomStringConvertible, Equatable, Comparable {
         self.value = value
     }
     
-    public func string(with decimals: Int? = nil) -> String {
+    public func string(with decimals: Int? = nil, roundingMode: NSDecimalNumber.RoundingMode = .down) -> String {
         let decimalsCount = decimals ?? self.decimals
         let formatter = NumberFormatter()
         formatter.locale = Locale.current
@@ -98,7 +98,7 @@ public struct Amount: CustomStringConvertible, Equatable, Comparable {
         formatter.alwaysShowsDecimalSeparator = true
         formatter.maximumFractionDigits = decimalsCount
         formatter.minimumFractionDigits = 2
-        let rounded = value.rounded(scale: decimalsCount)
+        let rounded = value.rounded(scale: decimalsCount, roundingMode: roundingMode)
         return formatter.string(from: rounded as NSDecimalNumber) ??
             "\(rounded) \(currencySymbol)"
     }


### PR DESCRIPTION
На странице кусамы в информационном сообщении значение
`0.000033333333`
 форматировалось как
`0.000033333332`

Буду пробрасывать режим округления, сейчас по-умолчанию там используется `.down`
