### PR TITLE
IOS-2411 Fixed initialization of currencysymbol/decimals

### DIFF
--- a/BlockchainSdk/Common/Amount.swift
+++ b/BlockchainSdk/Common/Amount.swift
@@ -77,8 +77,8 @@ public struct Amount: CustomStringConvertible, Equatable, Comparable {
     
     public init(with blockchain: Blockchain, type: AmountType = .coin, value: Decimal) {
         self.type = type
-        currencySymbol = blockchain.currencySymbol
-        decimals = blockchain.decimalCount
+        currencySymbol = type.token?.symbol ?? blockchain.currencySymbol
+        decimals = type.token?.decimalCount ?? blockchain.decimalCount
         self.value = value
     }
     

--- a/BlockchainSdkTests/Ethereum/EthereumTests.swift
+++ b/BlockchainSdkTests/Ethereum/EthereumTests.swift
@@ -69,7 +69,7 @@ class EthereumTests: XCTestCase {
         let destinationAddress = "0x7655b9b19ffab8b897f836857dae22a1e7f8d735"
         let nonce = 15
         let contractAddress = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-        let token = Token(name: "USDC Coin", symbol: "USDC", contractAddress: contractAddress, decimalCount: 6)
+        let token = Token(name: "USDC Coin", symbol: "USDC", contractAddress: contractAddress, decimalCount: 18)
         
         let walletAddress = try! addressService.makeAddress(from: walletPublicKey)
         let transactionBuilder = try! EthereumTransactionBuilder(walletPublicKey: walletPublicKey, chainId: 1)


### PR DESCRIPTION
В параметр type передаются значения отличные от `.coin` и `.reserve` только в нескольких случаях:

- getFiatBalance (то, что мы и чиним)
- в превью swiftui
- в dummyTx (а туда в свою очередь type = `.token` передается только в OptimismWalletManager.getFee 

Ничего не должно сломаться от фикса