### PR TITLE
IOS-2532: Remove Solana Serum

### DIFF
--- a/BlockchainSdk/Common/WalletManagerFactory.swift
+++ b/BlockchainSdk/Common/WalletManagerFactory.swift
@@ -280,7 +280,6 @@ public class WalletManagerFactory {
                     .quiknode(apiKey: config.quiknodeApiKey, subdomain: config.quiknodeSubdomain),
                     .ankr,
                     .mainnetBetaSolana,
-                    .mainnetBetaSerum
                 ]
                 let networkRouter = NetworkingRouter(endpoints: endpoints)
                 let accountStorage = SolanaDummyAccountStorage()


### PR DESCRIPTION
Отключаем Серум, из-за того что он не работает сейчас, постоянно шлет ошибку.