### PR TITLE
IOS-2763 Add support for multiple blockchair providers

### DIFF
--- a/BlockchainSdk/Common/BlockchainSdkConfig.swift
+++ b/BlockchainSdk/Common/BlockchainSdkConfig.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public struct BlockchainSdkConfig {
-    let blockchairApiKey: String
+    let blockchairApiKeys: [String]
     let blockcypherTokens: [String]
     let infuraProjectId: String
     let tronGridApiKey: String
@@ -19,7 +19,7 @@ public struct BlockchainSdkConfig {
     let networkProviderConfigurations: [Blockchain: NetworkProviderConfiguration]
 
     public init(
-        blockchairApiKey: String,
+        blockchairApiKeys: [String],
         blockcypherTokens: [String],
         infuraProjectId: String,
         tronGridApiKey: String,
@@ -28,7 +28,7 @@ public struct BlockchainSdkConfig {
         defaultNetworkProviderConfiguration: NetworkProviderConfiguration = .init(),
         networkProviderConfigurations: [Blockchain: NetworkProviderConfiguration] = [:]
     ) {
-        self.blockchairApiKey = blockchairApiKey
+        self.blockchairApiKeys = blockchairApiKeys
         self.blockcypherTokens = blockcypherTokens
         self.infuraProjectId = infuraProjectId
         self.tronGridApiKey = tronGridApiKey

--- a/BlockchainSdk/Common/WalletManagerFactory.swift
+++ b/BlockchainSdk/Common/WalletManagerFactory.swift
@@ -91,7 +91,7 @@ public class WalletManagerFactory {
                 var providers = [AnyBitcoinNetworkProvider]()
                 if !testnet {
                     providers.append(BlockchainInfoNetworkProvider(configuration: networkProviderConfiguration)
-                                        .eraseToAnyBitcoinNetworkProvider())
+                        .eraseToAnyBitcoinNetworkProvider())
                 }
                 providers.append(contentsOf: makeBlockchairNetworkProviders(for: .bitcoin(testnet: testnet),
                                                                             configuration: networkProviderConfiguration,
@@ -100,7 +100,7 @@ public class WalletManagerFactory {
                 providers.append(BlockcypherNetworkProvider(endpoint: .bitcoin(testnet: testnet),
                                                             tokens: config.blockcypherTokens,
                                                             configuration: networkProviderConfiguration)
-                                    .eraseToAnyBitcoinNetworkProvider())
+                    .eraseToAnyBitcoinNetworkProvider())
                 
                 $0.networkService = BitcoinNetworkService(providers: providers)
             }
@@ -122,7 +122,7 @@ public class WalletManagerFactory {
                 providers.append(BlockcypherNetworkProvider(endpoint: .litecoin,
                                                             tokens: config.blockcypherTokens,
                                                             configuration: networkProviderConfiguration)
-                                    .eraseToAnyBitcoinNetworkProvider())
+                    .eraseToAnyBitcoinNetworkProvider())
                 
                 $0.networkService = LitecoinNetworkService(providers: providers)
             }

--- a/BlockchainSdk/Common/WalletManagerFactory.swift
+++ b/BlockchainSdk/Common/WalletManagerFactory.swift
@@ -93,10 +93,10 @@ public class WalletManagerFactory {
                     providers.append(BlockchainInfoNetworkProvider(configuration: networkProviderConfiguration)
                                         .eraseToAnyBitcoinNetworkProvider())
                 }
-                providers.append(BlockchairNetworkProvider(endpoint: .bitcoin(testnet: testnet),
-                                                           apiKey: config.blockchairApiKey,
-                                                           configuration: networkProviderConfiguration)
-                                    .eraseToAnyBitcoinNetworkProvider())
+                providers.append(contentsOf: makeBlockchairNetworkProviders(for: .bitcoin(testnet: testnet),
+                                                                            configuration: networkProviderConfiguration,
+                                                                            apiKeys: config.blockchairApiKeys))
+
                 providers.append(BlockcypherNetworkProvider(endpoint: .bitcoin(testnet: testnet),
                                                             tokens: config.blockcypherTokens,
                                                             configuration: networkProviderConfiguration)
@@ -115,10 +115,10 @@ public class WalletManagerFactory {
                 $0.txBuilder = BitcoinTransactionBuilder(bitcoinManager: bitcoinManager, addresses: wallet.addresses)
                 
                 var providers = [AnyBitcoinNetworkProvider]()
-                providers.append(BlockchairNetworkProvider(endpoint: .litecoin,
-                                                           apiKey: config.blockchairApiKey,
-                                                           configuration: networkProviderConfiguration)
-                                    .eraseToAnyBitcoinNetworkProvider())
+                providers.append(contentsOf: makeBlockchairNetworkProviders(for: .litecoin,
+                                                                            configuration: networkProviderConfiguration,
+                                                                            apiKeys: config.blockchairApiKeys))
+
                 providers.append(BlockcypherNetworkProvider(endpoint: .litecoin,
                                                             tokens: config.blockcypherTokens,
                                                             configuration: networkProviderConfiguration)
@@ -135,22 +135,19 @@ public class WalletManagerFactory {
                                                     bip: .bip44)
                 
                 $0.txBuilder = BitcoinTransactionBuilder(bitcoinManager: bitcoinManager, addresses: wallet.addresses)
-                
-                let providers: [AnyBitcoinNetworkProvider] = [
-                    BlockchairNetworkProvider(
-                        endpoint: .dogecoin,
-                        apiKey: config.blockchairApiKey,
-                        configuration: networkProviderConfiguration
-                    )
-                    .eraseToAnyBitcoinNetworkProvider(),
-                    BlockcypherNetworkProvider(
-                        endpoint: .dogecoin,
-                        tokens: config.blockcypherTokens,
-                        configuration: networkProviderConfiguration
-                    )
-                    .eraseToAnyBitcoinNetworkProvider()
-                ]
-                
+
+                var providers = [AnyBitcoinNetworkProvider]()
+                providers.append(contentsOf: makeBlockchairNetworkProviders(for: .dogecoin,
+                                                                            configuration: networkProviderConfiguration,
+                                                                            apiKeys: config.blockchairApiKeys))
+
+                providers.append(BlockcypherNetworkProvider(
+                    endpoint: .dogecoin,
+                    tokens: config.blockcypherTokens,
+                    configuration: networkProviderConfiguration
+                )
+                    .eraseToAnyBitcoinNetworkProvider())
+
                 $0.networkService = BitcoinNetworkService(providers: providers)
             }
             
@@ -182,7 +179,6 @@ public class WalletManagerFactory {
             }
             
             let blockcypherProvider: BlockcypherNetworkProvider?
-            let blockchairProvider: BlockchairNetworkProvider?
             
             if case .ethereum = blockchain {
                 blockcypherProvider = BlockcypherNetworkProvider(
@@ -190,15 +186,8 @@ public class WalletManagerFactory {
                     tokens: config.blockcypherTokens,
                     configuration: networkProviderConfiguration
                 )
-                
-                blockchairProvider = BlockchairNetworkProvider(
-                    endpoint: .ethereum(testnet: blockchain.isTestnet),
-                    apiKey: config.blockchairApiKey,
-                    configuration: networkProviderConfiguration
-                )
             } else {
                 blockcypherProvider = nil
-                blockchairProvider = nil
             }
             
             return try manager.then {
@@ -211,7 +200,7 @@ public class WalletManagerFactory {
                 $0.networkService = EthereumNetworkService(decimals: blockchain.decimalCount,
                                                            providers: jsonRpcProviders,
                                                            blockcypherProvider: blockcypherProvider,
-                                                           blockchairProvider: blockchairProvider)
+                                                           blockchairProvider: nil) //TODO: TBD Do we need the TokenFinder feature?
             }
             
         case .bitcoinCash(let testnet):
@@ -226,11 +215,10 @@ public class WalletManagerFactory {
                 
                 //TODO: Add testnet support. Maybe https://developers.cryptoapis.io/technical-documentation/general-information/what-we-support
                 var providers = [AnyBitcoinNetworkProvider]()
-                providers.append(BlockchairNetworkProvider(
-                    endpoint: .bitcoinCash,
-                    apiKey: config.blockchairApiKey,
-                    configuration: networkProviderConfiguration
-                ).eraseToAnyBitcoinNetworkProvider())
+                providers.append(contentsOf: makeBlockchairNetworkProviders(for: .bitcoinCash,
+                                                                            configuration: networkProviderConfiguration,
+                                                                            apiKeys: config.blockchairApiKeys))
+
                 $0.networkService = BitcoinCashNetworkService(providers: providers)
             }
 
@@ -344,23 +332,31 @@ public class WalletManagerFactory {
             // TODO: Add CryptoAPIs for testnet
             
             $0.txBuilder = BitcoinTransactionBuilder(bitcoinManager: bitcoinManager, addresses: wallet.addresses)
+
+            var providers: [AnyBitcoinNetworkProvider] = []
+
+            providers.append(contentsOf: makeBlockchairNetworkProviders(for: .dash,
+                                                                        configuration: networkProviderConfiguration,
+                                                                        apiKeys: config.blockchairApiKeys))
+
+            providers.append(BlockcypherNetworkProvider(endpoint: .dash,
+                                                        tokens: config.blockcypherTokens,
+                                                        configuration: networkProviderConfiguration)
+                .eraseToAnyBitcoinNetworkProvider())
             
-            let blockchairProvider = BlockchairNetworkProvider(
-                endpoint: .dash,
-                apiKey: config.blockchairApiKey,
-                configuration: networkProviderConfiguration
-            )
-            let blockcypherProvider = BlockcypherNetworkProvider(
-                endpoint: .dash,
-                tokens: config.blockcypherTokens,
-                configuration: networkProviderConfiguration
-            )
-            
-            $0.networkService = BitcoinNetworkService(
-                providers: [blockchairProvider.eraseToAnyBitcoinNetworkProvider(),
-                            blockcypherProvider.eraseToAnyBitcoinNetworkProvider()]
-            )
+            $0.networkService = BitcoinNetworkService(providers: providers)
         }
+    }
+
+    private func makeBlockchairNetworkProviders(for endpoint: BlockchairEndpoint, configuration: NetworkProviderConfiguration, apiKeys: [String]) -> [AnyBitcoinNetworkProvider] {
+        let apiKeys: [String?] = [nil] + apiKeys
+
+        let providers = apiKeys.map {
+            BlockchairNetworkProvider(endpoint: endpoint, apiKey: $0, configuration: configuration)
+                .eraseToAnyBitcoinNetworkProvider()
+        }
+
+        return providers
     }
 }
 


### PR DESCRIPTION
Добавил поддержку нескольких блокчеир провайдеров.

- Вынес переключение без ключа/с ключом из провайдера. Теперь будут создаваться несколько провайдеров: с ключами и без. За переключение будет отвечать наш универсальный MultiNetworkProvider
- Потерялись при рефакторинге проверки на конкретные коды ошибок, но это особо и не было нужно. Наоборот, без них надежнее.
- В эфир блокчеир пока не передаю, потому что нужно немного переделывать нетворк сервис. Блокчеир нужен только для поиска erc20 токенов. Сейчас это не используется и думаю не будет, потому что находились далеко не все токены.
- В дальнейшем нужно будет также отрефакторить блоксайфер
- Переключение проверил