### PR TITLE
IOS-2763 Distinguish blockchair providers by host 

### DIFF
--- a/BlockchainSdk/BlockchainService/Blockchair/BlockchairNetworkProvider.swift
+++ b/BlockchainSdk/BlockchainService/Blockchair/BlockchairNetworkProvider.swift
@@ -38,7 +38,9 @@ class BlockchairNetworkProvider: BitcoinNetworkProvider {
     }()
     
     var host: String {
-        BlockchairTarget(type: .fee(endpoint: endpoint), apiKey: nil).baseURL.hostOrUnknown
+        let baseUrl = "https://api.blockchair.com/"
+        let suffix = apiKey?.sha256() ?? "nil"
+        return "\(baseUrl)_\(suffix)"
     }
     
     init(endpoint: BlockchairEndpoint, apiKey: String?, configuration: NetworkProviderConfiguration) {

--- a/BlockchainSdk/Common/API/MultiNetworkProvider.swift
+++ b/BlockchainSdk/Common/API/MultiNetworkProvider.swift
@@ -54,7 +54,7 @@ extension MultiNetworkProvider {
     // NOTE: There also copy of this behaviour in the wild, if you want to update something
     // in the code, don't forget to update also Solano.Swift framework, class NetworkingRouter
     private func needRetry(for errorHost: String) -> Bool {
-        if errorHost != self.host {
+        if errorHost != self.host { // Do not switch the provider, if it was switched already
             return true
         }
         


### PR DESCRIPTION
Нужно все же различать провайдеры на одном хосте, но с разными ключами, чтобы не произошло нежелательного двойного переключения при параллельных запросах