### PR TITLE
Fix The "<" not displayed for some blockchains [IOS-2821]

### DIFF
--- a/BlockchainSdk/Common/Blockchain.swift
+++ b/BlockchainSdk/Common/Blockchain.swift
@@ -247,6 +247,14 @@ public enum Blockchain: Equatable, Hashable {
             if case .token = amountType {
                 return true
             }
+        case .ethereumPoW:
+            if case .token = amountType {
+                return true
+            }
+        case .avalanche:
+            if case .token = amountType {
+                return true
+            }
         default:
             break
         }

--- a/BlockchainSdk/Common/Blockchain.swift
+++ b/BlockchainSdk/Common/Blockchain.swift
@@ -241,17 +241,9 @@ public enum Blockchain: Equatable, Hashable {
     
     public func isFeeApproximate(for amountType: Amount.AmountType) -> Bool {
         switch self {
-        case .arbitrum, .stellar, .optimism:
+        case .arbitrum, .stellar, .optimism, .ethereumPoW:
             return true
-        case .fantom, .tron, .gnosis:
-            if case .token = amountType {
-                return true
-            }
-        case .ethereumPoW:
-            if case .token = amountType {
-                return true
-            }
-        case .avalanche:
+        case .fantom, .tron, .gnosis, .avalanche:
             if case .token = amountType {
                 return true
             }


### PR DESCRIPTION
Добавить знак < в поле комиссии для

- Для блокчейна ETH POW
- Для токенов ETH POW
- Только для токенов Avalanche