### PR TITLE
IOS-3095 Remove trailing zeroes from ethereum balance if the balance …

### DIFF
--- a/BlockchainSdk/Common/Utils/EthereumUtils.swift
+++ b/BlockchainSdk/Common/Utils/EthereumUtils.swift
@@ -19,8 +19,7 @@ public enum EthereumUtils {
         
         let balanceData: Data
         if data.count > standardBalancePayloadLength,
-           data.suffix(from: standardBalancePayloadLength).allSatisfy({ $0 == 0 })
-        {
+           data.suffix(from: standardBalancePayloadLength).allSatisfy({ $0 == 0 }) {
             balanceData = data.prefix(standardBalancePayloadLength)
         } else {
             balanceData = data

--- a/BlockchainSdk/Common/Utils/EthereumUtils.swift
+++ b/BlockchainSdk/Common/Utils/EthereumUtils.swift
@@ -10,8 +10,20 @@ import Foundation
 
 public enum EthereumUtils {
     public static func parseEthereumDecimal(_ string: String, decimalsCount: Int) -> Decimal? {
-        guard let balanceData = asciiHexToData(string.removeHexPrefix())  else {
+        guard let data = asciiHexToData(string.removeHexPrefix()) else {
             return nil
+        }
+        
+        // Some contracts (namely vBUSD) send 32 bytes of balance plus 64 bytes of zeroes
+        let standardBalancePayloadLength = 32
+        
+        let balanceData: Data
+        if data.count > standardBalancePayloadLength,
+           data.suffix(from: standardBalancePayloadLength).allSatisfy({ $0 == 0 })
+        {
+            balanceData = data.prefix(standardBalancePayloadLength)
+        } else {
+            balanceData = data
         }
         
         let decimals = Int16(decimalsCount)

--- a/BlockchainSdk/Common/Utils/EthereumUtils.swift
+++ b/BlockchainSdk/Common/Utils/EthereumUtils.swift
@@ -14,15 +14,16 @@ public enum EthereumUtils {
             return nil
         }
         
-        // Some contracts (namely vBUSD) send 32 bytes of balance plus 64 bytes of zeroes
-        let standardBalancePayloadLength = 32
+        // ERC-20 standard defines balanceOf function as returning uint256. Don't accept anything else.
+        let uint256Size = 32
         
         let balanceData: Data
-        if data.count > standardBalancePayloadLength,
-           data.suffix(from: standardBalancePayloadLength).allSatisfy({ $0 == 0 }) {
-            balanceData = data.prefix(standardBalancePayloadLength)
-        } else {
+        if data.count <= uint256Size {
             balanceData = data
+        } else if data.suffix(from: uint256Size).allSatisfy({ $0 == 0 }) {
+            balanceData = data.prefix(uint256Size)
+        } else {
+            return nil
         }
         
         let decimals = Int16(decimalsCount)

--- a/BlockchainSdkTests/Ethereum/EthereumTests.swift
+++ b/BlockchainSdkTests/Ethereum/EthereumTests.swift
@@ -92,7 +92,15 @@ class EthereumTests: XCTestCase {
     
     func testParseBalance() {
         let hex = "0x373c91e25f1040"
+        let hex2 = "0x00000000000000000000000000000000000000000000000000373c91e25f1040"
         XCTAssertEqual(EthereumUtils.parseEthereumDecimal(hex, decimalsCount: 18)!.description, "0.015547720984891456")
+        XCTAssertEqual(EthereumUtils.parseEthereumDecimal(hex2, decimalsCount: 18)!.description, "0.015547720984891456")
+        
+        // vBUSD contract sends extra zeros
+        let vBUSDHexWithExtraZeros = "0x0000000000000000000000000000000000000000000000000000005a8c504ec900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        let vBUSDHexWithoutExtraZeros = "0x0000000000000000000000000000000000000000000000000000005a8c504ec9"
+        print(EthereumUtils.parseEthereumDecimal(vBUSDHexWithExtraZeros,    decimalsCount: 18)!.description, "0.000000388901129929")
+        print(EthereumUtils.parseEthereumDecimal(vBUSDHexWithoutExtraZeros, decimalsCount: 18)!.description, "0.000000388901129929")
         
         let tooBig = "0x01234567890abcdef01234567890abcdef01234501234567890abcdef01234567890abcdef01234501234567890abcdef012345def01234501234567890abcdef012345def01234501234567890abcdef012345def01234501234567890abcdef01234567890abcdef012345"
         XCTAssertNil(EthereumUtils.parseEthereumDecimal(tooBig, decimalsCount: 18))

--- a/BlockchainSdkTests/Ethereum/EthereumTests.swift
+++ b/BlockchainSdkTests/Ethereum/EthereumTests.swift
@@ -102,6 +102,7 @@ class EthereumTests: XCTestCase {
         XCTAssertEqual(EthereumUtils.parseEthereumDecimal(vBUSDHexWithExtraZeros,    decimalsCount: 18)!.description, "0.000000388901129929")
         XCTAssertEqual(EthereumUtils.parseEthereumDecimal(vBUSDHexWithoutExtraZeros, decimalsCount: 18)!.description, "0.000000388901129929")
         
+        // This is rubbish and we don't expect to receive this but at least it should not throw exceptions
         let tooBig = "0x01234567890abcdef01234567890abcdef01234501234567890abcdef01234567890abcdef01234501234567890abcdef012345def01234501234567890abcdef012345def01234501234567890abcdef012345def01234501234567890abcdef01234567890abcdef012345"
         XCTAssertNil(EthereumUtils.parseEthereumDecimal(tooBig, decimalsCount: 18))
     }

--- a/BlockchainSdkTests/Ethereum/EthereumTests.swift
+++ b/BlockchainSdkTests/Ethereum/EthereumTests.swift
@@ -99,8 +99,8 @@ class EthereumTests: XCTestCase {
         // vBUSD contract sends extra zeros
         let vBUSDHexWithExtraZeros = "0x0000000000000000000000000000000000000000000000000000005a8c504ec900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
         let vBUSDHexWithoutExtraZeros = "0x0000000000000000000000000000000000000000000000000000005a8c504ec9"
-        print(EthereumUtils.parseEthereumDecimal(vBUSDHexWithExtraZeros,    decimalsCount: 18)!.description, "0.000000388901129929")
-        print(EthereumUtils.parseEthereumDecimal(vBUSDHexWithoutExtraZeros, decimalsCount: 18)!.description, "0.000000388901129929")
+        XCTAssertEqual(EthereumUtils.parseEthereumDecimal(vBUSDHexWithExtraZeros,    decimalsCount: 18)!.description, "0.000000388901129929")
+        XCTAssertEqual(EthereumUtils.parseEthereumDecimal(vBUSDHexWithoutExtraZeros, decimalsCount: 18)!.description, "0.000000388901129929")
         
         let tooBig = "0x01234567890abcdef01234567890abcdef01234501234567890abcdef01234567890abcdef01234501234567890abcdef012345def01234501234567890abcdef012345def01234501234567890abcdef012345def01234501234567890abcdef01234567890abcdef012345"
         XCTAssertNil(EthereumUtils.parseEthereumDecimal(tooBig, decimalsCount: 18))


### PR DESCRIPTION
…data is more than the standard 32 bytes