### PR TITLE
IOS-3120 Fixing BlockBook estimatesmartfee implementation

### DIFF
--- a/BlockchainSdk/BlockchainService/BlockBook/BlockBookTarget.swift
+++ b/BlockchainSdk/BlockchainService/BlockBook/BlockBookTarget.swift
@@ -48,8 +48,8 @@ struct BlockBookTarget: TargetType {
         switch request {
         case .txDetails, .send, .utxo:
             return .requestPlain
-        case .fees:
-            return .requestJSONEncodable(BitcoinNodeEstimateSmartFeeParameters())
+        case .fees(let confirmationBlocks):
+            return .requestJSONEncodable(BitcoinNodeEstimateSmartFeeParameters(confirmationBlocks: confirmationBlocks))
         case .address:
             return .requestParameters(parameters: ["details": "txs"], encoding: URLEncoding.default)
         }
@@ -69,7 +69,7 @@ extension BlockBookTarget {
         case send(txHex: String)
         case txDetails(txHash: String)
         case utxo(address: String)
-        case fees
+        case fees(confirmationBlocks: Int)
     }
 }
 
@@ -78,7 +78,9 @@ fileprivate struct BitcoinNodeEstimateSmartFeeParameters: Encodable {
     let jsonrpc = "2.0"
     let id = "id"
     let method = "estimatesmartfee"
-    let params = [
-        25 // Number of blocks that we want the transaction to be confirmed within
-    ]
+    let params: [Int]
+    
+    init(confirmationBlocks: Int) {
+        self.params = [confirmationBlocks]
+    }
 }

--- a/BlockchainSdk/BlockchainService/BlockBook/BlockBookTarget.swift
+++ b/BlockchainSdk/BlockchainService/BlockBook/BlockBookTarget.swift
@@ -79,6 +79,6 @@ fileprivate struct BitcoinNodeEstimateSmartFeeParameters: Encodable {
     let id = "id"
     let method = "estimatesmartfee"
     let params = [
-        1000 // Number of blocks to consider
+        25 // Number of blocks that we want the transaction to be confirmed within
     ]
 }

--- a/BlockchainSdk/BlockchainService/BlockBook/BlockBookUtxoProvider.swift
+++ b/BlockchainSdk/BlockchainService/BlockBook/BlockBookUtxoProvider.swift
@@ -204,7 +204,7 @@ extension BlockBookUtxoProvider: BitcoinNetworkProvider {
         .collect()
         .map { $0.sorted() }
         .tryMap { fees -> BitcoinFee in
-            guard fees.count == 3 else {
+            guard fees.count == confirmationBlocks.count else {
                 throw BlockchainSdkError.failedToLoadFee
             }
             

--- a/BlockchainSdk/BlockchainService/BlockBook/BlockBookUtxoProvider.swift
+++ b/BlockchainSdk/BlockchainService/BlockBook/BlockBookUtxoProvider.swift
@@ -183,6 +183,10 @@ extension BlockBookUtxoProvider: BitcoinNetworkProvider {
                     throw WalletError.empty
                 }
                 
+                if $0.result.feerate <= 0 {
+                    throw BlockchainSdkError.failedToLoadFee
+                }
+                
                 let feeRate = Decimal($0.result.feerate) * self.blockchain.decimalValue
                 
                 let min = (Decimal(0.8) * feeRate).rounded(roundingMode: .down)

--- a/BlockchainSdk/BlockchainService/BlockBook/BlockBookUtxoProvider.swift
+++ b/BlockchainSdk/BlockchainService/BlockBook/BlockBookUtxoProvider.swift
@@ -187,11 +187,12 @@ extension BlockBookUtxoProvider: BitcoinNetworkProvider {
                     throw BlockchainSdkError.failedToLoadFee
                 }
                 
-                let feeRate = Decimal($0.result.feerate) * self.blockchain.decimalValue
+                let bytesInKiloByte: Decimal = 1024
+                let feeRatePerByte = Decimal($0.result.feerate) * self.blockchain.decimalValue / bytesInKiloByte
                 
-                let min = (Decimal(0.8) * feeRate).rounded(roundingMode: .up)
-                let normal = feeRate.rounded(roundingMode: .up)
-                let max = (Decimal(1.2) * feeRate).rounded(roundingMode: .up)
+                let min = (Decimal(0.8) * feeRatePerByte).rounded(roundingMode: .up)
+                let normal = feeRatePerByte.rounded(roundingMode: .up)
+                let max = (Decimal(1.2) * feeRatePerByte).rounded(roundingMode: .up)
                 
                 return BitcoinFee(minimalSatoshiPerByte: min, normalSatoshiPerByte: normal, prioritySatoshiPerByte: max)
             }

--- a/BlockchainSdk/BlockchainService/BlockBook/BlockBookUtxoProvider.swift
+++ b/BlockchainSdk/BlockchainService/BlockBook/BlockBookUtxoProvider.swift
@@ -199,7 +199,7 @@ extension BlockBookUtxoProvider: BitcoinNetworkProvider {
     func getFee() -> AnyPublisher<BitcoinFee, Error> {
         // Number of blocks we want the transaction to be confirmed in.
         // The lower the number the bigger the fee returned by 'estimatesmartfee'.
-        let confirmationBlocks = [10, 5, 1]
+        let confirmationBlocks = [8, 4, 1]
         
         return Publishers.MergeMany(confirmationBlocks.map {
             getFeeRatePerByte(for: $0)

--- a/BlockchainSdk/BlockchainService/BlockBook/BlockBookUtxoProvider.swift
+++ b/BlockchainSdk/BlockchainService/BlockBook/BlockBookUtxoProvider.swift
@@ -189,9 +189,9 @@ extension BlockBookUtxoProvider: BitcoinNetworkProvider {
                 
                 let feeRate = Decimal($0.result.feerate) * self.blockchain.decimalValue
                 
-                let min = (Decimal(0.8) * feeRate).rounded(roundingMode: .down)
-                let normal = feeRate
-                let max = (Decimal(1.2) * feeRate).rounded(roundingMode: .down)
+                let min = (Decimal(0.8) * feeRate).rounded(roundingMode: .up)
+                let normal = feeRate.rounded(roundingMode: .up)
+                let max = (Decimal(1.2) * feeRate).rounded(roundingMode: .up)
                 
                 return BitcoinFee(minimalSatoshiPerByte: min, normalSatoshiPerByte: normal, prioritySatoshiPerByte: max)
             }

--- a/BlockchainSdk/BlockchainService/BlockBook/BlockBookUtxoProvider.swift
+++ b/BlockchainSdk/BlockchainService/BlockBook/BlockBookUtxoProvider.swift
@@ -163,6 +163,7 @@ class BlockBookUtxoProvider {
                     throw BlockchainSdkError.failedToLoadFee
                 }
                 
+                // estimatesmartfee returns fee in currency per kilobyte
                 let bytesInKiloByte: Decimal = 1024
                 let feeRatePerByte = Decimal($0.result.feerate) * self.blockchain.decimalValue / bytesInKiloByte
                 
@@ -196,6 +197,8 @@ extension BlockBookUtxoProvider: BitcoinNetworkProvider {
     }
     
     func getFee() -> AnyPublisher<BitcoinFee, Error> {
+        // Number of blocks we want the transaction to be confirmed in.
+        // The lower the number the bigger the fee returned by 'estimatesmartfee'.
         let confirmationBlocks = [10, 5, 1]
         
         return Publishers.MergeMany(confirmationBlocks.map {

--- a/BlockchainSdk/Common/BlockchainSdkConfig.swift
+++ b/BlockchainSdk/Common/BlockchainSdkConfig.swift
@@ -12,6 +12,7 @@ public struct BlockchainSdkConfig {
     let blockchairApiKeys: [String]
     let blockcypherTokens: [String]
     let infuraProjectId: String
+    let useBlockBookUtxoApis: Bool
     let nowNodesApiKey: String
     let getBlockApiKey: String
     let tronGridApiKey: String
@@ -25,6 +26,7 @@ public struct BlockchainSdkConfig {
         blockchairApiKeys: [String],
         blockcypherTokens: [String],
         infuraProjectId: String,
+        useBlockBookUtxoApis: Bool,
         nowNodesApiKey: String,
         getBlockApiKey: String,
         tronGridApiKey: String,
@@ -37,6 +39,7 @@ public struct BlockchainSdkConfig {
         self.blockchairApiKeys = blockchairApiKeys
         self.blockcypherTokens = blockcypherTokens
         self.infuraProjectId = infuraProjectId
+        self.useBlockBookUtxoApis = useBlockBookUtxoApis
         self.nowNodesApiKey = nowNodesApiKey
         self.getBlockApiKey = getBlockApiKey
         self.tronGridApiKey = tronGridApiKey

--- a/BlockchainSdk/Common/WalletManagerFactory.swift
+++ b/BlockchainSdk/Common/WalletManagerFactory.swift
@@ -77,6 +77,8 @@ public class WalletManagerFactory {
         
         let networkProviderConfiguration = config.networkProviderConfiguration(for: blockchain)
         
+        let useBlockBookUtxoApis = config.useBlockBookUtxoApis
+        
         switch blockchain {
         case .bitcoin(let testnet):
             return try BitcoinWalletManager(wallet: wallet).then {
@@ -90,16 +92,20 @@ public class WalletManagerFactory {
                 
                 var providers = [AnyBitcoinNetworkProvider]()
                 
-                providers.append(BlockBookUtxoProvider(blockchain: blockchain,
-                                                       blockBookConfig: NowNodesBlockBookConfig(apiKey: config.nowNodesApiKey),
-                                                       networkConfiguration: networkProviderConfiguration)
-                    .eraseToAnyBitcoinNetworkProvider())
-                
-                if !testnet {
+                if useBlockBookUtxoApis {
                     providers.append(BlockBookUtxoProvider(blockchain: blockchain,
-                                                           blockBookConfig: GetBlockBlockBookConfig(apiKey: config.getBlockApiKey),
+                                                           blockBookConfig: NowNodesBlockBookConfig(apiKey: config.nowNodesApiKey),
                                                            networkConfiguration: networkProviderConfiguration)
                         .eraseToAnyBitcoinNetworkProvider())
+                }
+                
+                if !testnet {
+                    if useBlockBookUtxoApis {
+                        providers.append(BlockBookUtxoProvider(blockchain: blockchain,
+                                                               blockBookConfig: GetBlockBlockBookConfig(apiKey: config.getBlockApiKey),
+                                                               networkConfiguration: networkProviderConfiguration)
+                            .eraseToAnyBitcoinNetworkProvider())
+                    }
                     
                     providers.append(BlockchainInfoNetworkProvider(configuration: networkProviderConfiguration)
                         .eraseToAnyBitcoinNetworkProvider())
@@ -128,15 +134,17 @@ public class WalletManagerFactory {
                 
                 var providers = [AnyBitcoinNetworkProvider]()
                 
-                providers.append(BlockBookUtxoProvider(blockchain: blockchain,
-                                                       blockBookConfig: NowNodesBlockBookConfig(apiKey: config.nowNodesApiKey),
-                                                       networkConfiguration: networkProviderConfiguration)
-                    .eraseToAnyBitcoinNetworkProvider())
-                
-                providers.append(BlockBookUtxoProvider(blockchain: blockchain,
-                                                       blockBookConfig: GetBlockBlockBookConfig(apiKey: config.getBlockApiKey),
-                                                       networkConfiguration: networkProviderConfiguration)
-                    .eraseToAnyBitcoinNetworkProvider())
+                if useBlockBookUtxoApis {
+                    providers.append(BlockBookUtxoProvider(blockchain: blockchain,
+                                                           blockBookConfig: NowNodesBlockBookConfig(apiKey: config.nowNodesApiKey),
+                                                           networkConfiguration: networkProviderConfiguration)
+                        .eraseToAnyBitcoinNetworkProvider())
+                    
+                    providers.append(BlockBookUtxoProvider(blockchain: blockchain,
+                                                           blockBookConfig: GetBlockBlockBookConfig(apiKey: config.getBlockApiKey),
+                                                           networkConfiguration: networkProviderConfiguration)
+                        .eraseToAnyBitcoinNetworkProvider())
+                }
                 
                 providers.append(contentsOf: makeBlockchairNetworkProviders(for: .litecoin,
                                                                             configuration: networkProviderConfiguration,
@@ -161,15 +169,17 @@ public class WalletManagerFactory {
                 
                 var providers = [AnyBitcoinNetworkProvider]()
                 
-                providers.append(BlockBookUtxoProvider(blockchain: blockchain,
-                                                       blockBookConfig: NowNodesBlockBookConfig(apiKey: config.nowNodesApiKey),
-                                                       networkConfiguration: networkProviderConfiguration)
-                    .eraseToAnyBitcoinNetworkProvider())
-                
-                providers.append(BlockBookUtxoProvider(blockchain: blockchain,
-                                                       blockBookConfig: GetBlockBlockBookConfig(apiKey: config.getBlockApiKey),
-                                                       networkConfiguration: networkProviderConfiguration)
-                    .eraseToAnyBitcoinNetworkProvider())
+                if useBlockBookUtxoApis {
+                    providers.append(BlockBookUtxoProvider(blockchain: blockchain,
+                                                           blockBookConfig: NowNodesBlockBookConfig(apiKey: config.nowNodesApiKey),
+                                                           networkConfiguration: networkProviderConfiguration)
+                        .eraseToAnyBitcoinNetworkProvider())
+                    
+                    providers.append(BlockBookUtxoProvider(blockchain: blockchain,
+                                                           blockBookConfig: GetBlockBlockBookConfig(apiKey: config.getBlockApiKey),
+                                                           networkConfiguration: networkProviderConfiguration)
+                        .eraseToAnyBitcoinNetworkProvider())
+                }
                 
                 providers.append(contentsOf: makeBlockchairNetworkProviders(for: .dogecoin,
                                                                             configuration: networkProviderConfiguration,
@@ -396,15 +406,17 @@ public class WalletManagerFactory {
             
             var providers: [AnyBitcoinNetworkProvider] = []
             
-            providers.append(BlockBookUtxoProvider(blockchain: .dash(testnet: testnet),
-                                                   blockBookConfig: NowNodesBlockBookConfig(apiKey: config.nowNodesApiKey),
-                                                   networkConfiguration: networkProviderConfiguration)
-                .eraseToAnyBitcoinNetworkProvider())
-            
-            providers.append(BlockBookUtxoProvider(blockchain: .dash(testnet: testnet),
-                                                   blockBookConfig: GetBlockBlockBookConfig(apiKey: config.getBlockApiKey),
-                                                   networkConfiguration: networkProviderConfiguration)
-                .eraseToAnyBitcoinNetworkProvider())
+            if config.useBlockBookUtxoApis {
+                providers.append(BlockBookUtxoProvider(blockchain: .dash(testnet: testnet),
+                                                       blockBookConfig: NowNodesBlockBookConfig(apiKey: config.nowNodesApiKey),
+                                                       networkConfiguration: networkProviderConfiguration)
+                    .eraseToAnyBitcoinNetworkProvider())
+                
+                providers.append(BlockBookUtxoProvider(blockchain: .dash(testnet: testnet),
+                                                       blockBookConfig: GetBlockBlockBookConfig(apiKey: config.getBlockApiKey),
+                                                       networkConfiguration: networkProviderConfiguration)
+                    .eraseToAnyBitcoinNetworkProvider())
+            }
             
             providers.append(contentsOf: makeBlockchairNetworkProviders(for: .dash,
                                                                         configuration: networkProviderConfiguration,

--- a/BlockchainSdk/WalletManagers/Bitcoin/BitcoinTransactionBuilder.swift
+++ b/BlockchainSdk/WalletManagers/Bitcoin/BitcoinTransactionBuilder.swift
@@ -35,7 +35,7 @@ class BitcoinTransactionBuilder {
 	var feeRates: [Decimal: Int] = [:]
     var bitcoinManager: BitcoinManager
     
-    private var changeScript: Data?
+    private(set) var changeScript: Data?
 	private let walletScripts: [HDWalletScript]
 
 	init(bitcoinManager: BitcoinManager, addresses: [Address]) {

--- a/BlockchainSdk/WalletManagers/Bitcoin/BitcoinWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Bitcoin/BitcoinWalletManager.swift
@@ -110,9 +110,9 @@ class BitcoinWalletManager: BaseManager, WalletManager {
     private func processFee(_ response: BitcoinFee, amount: Amount, destination: String) -> [Amount] {
         // Don't remove `.rounded` from here, intValue can sometimes go crazy
         // e.g. with the Decimal of (662701 / 3), producing 0 integer
-        var minRate = (max(response.minimalSatoshiPerByte, minimalFeePerByte).rounded(roundingMode: .down) as NSDecimalNumber).intValue
-        var normalRate = (max(response.normalSatoshiPerByte, minimalFeePerByte).rounded(roundingMode: .down) as NSDecimalNumber).intValue
-        var maxRate = (max(response.prioritySatoshiPerByte, minimalFeePerByte).rounded(roundingMode: .down) as NSDecimalNumber).intValue
+        var minRate = (max(response.minimalSatoshiPerByte, minimalFeePerByte).rounded(roundingMode: .up) as NSDecimalNumber).intValue
+        var normalRate = (max(response.normalSatoshiPerByte, minimalFeePerByte).rounded(roundingMode: .up) as NSDecimalNumber).intValue
+        var maxRate = (max(response.prioritySatoshiPerByte, minimalFeePerByte).rounded(roundingMode: .up) as NSDecimalNumber).intValue
         
         var minFee = txBuilder.bitcoinManager.fee(for: amount.value, address: destination, feeRate: minRate, senderPay: false, changeScript: nil, sequence: .max)
         var normalFee = txBuilder.bitcoinManager.fee(for: amount.value, address: destination, feeRate: normalRate, senderPay: false, changeScript: nil, sequence: .max)

--- a/BlockchainSdk/WalletManagers/Bitcoin/BitcoinWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Bitcoin/BitcoinWalletManager.swift
@@ -108,9 +108,11 @@ class BitcoinWalletManager: BaseManager, WalletManager {
     }
     
     private func processFee(_ response: BitcoinFee, amount: Amount, destination: String) -> [Amount] {
-        var minRate = (max(response.minimalSatoshiPerByte, minimalFeePerByte) as NSDecimalNumber).intValue
-        var normalRate = (max(response.normalSatoshiPerByte, minimalFeePerByte) as NSDecimalNumber).intValue
-        var maxRate = (max(response.prioritySatoshiPerByte, minimalFeePerByte) as NSDecimalNumber).intValue
+        // Don't remove `.rounded` from here, intValue can sometimes go crazy
+        // e.g. with the Decimal of (662701 / 3), producing 0 integer
+        var minRate = (max(response.minimalSatoshiPerByte, minimalFeePerByte).rounded(roundingMode: .down) as NSDecimalNumber).intValue
+        var normalRate = (max(response.normalSatoshiPerByte, minimalFeePerByte).rounded(roundingMode: .down) as NSDecimalNumber).intValue
+        var maxRate = (max(response.prioritySatoshiPerByte, minimalFeePerByte).rounded(roundingMode: .down) as NSDecimalNumber).intValue
         
         var minFee = txBuilder.bitcoinManager.fee(for: amount.value, address: destination, feeRate: minRate, senderPay: false, changeScript: nil, sequence: .max)
         var normalFee = txBuilder.bitcoinManager.fee(for: amount.value, address: destination, feeRate: normalRate, senderPay: false, changeScript: nil, sequence: .max)

--- a/BlockchainSdk/WalletManagers/Bitcoin/Network/BitcoinNetworkService.swift
+++ b/BlockchainSdk/WalletManagers/Bitcoin/Network/BitcoinNetworkService.swift
@@ -42,7 +42,10 @@ class BitcoinNetworkService: MultiNetworkProvider, BitcoinNetworkProvider {
         Publishers.MergeMany(providers.map {
             $0.getFee()
                 .retry(2)
-                .replaceError(with: BitcoinFee(minimalSatoshiPerByte: 0, normalSatoshiPerByte: 0, prioritySatoshiPerByte: 0))
+                .catch { _ in
+                    Empty()
+                        .setFailureType(to: Error.self)
+                }
                 .eraseToAnyPublisher()
         })
         .collect()

--- a/BlockchainSdk/WalletManagers/Dogecoin/DogecoinNetworkParams.swift
+++ b/BlockchainSdk/WalletManagers/Dogecoin/DogecoinNetworkParams.swift
@@ -28,5 +28,5 @@ class DogecoinNetworkParams: INetwork {
         "seed.doger.dogecoin.com"
     ]
     
-    let dustRelayTxFee: Int = 100000000
+    let dustRelayTxFee: Int = 1_000_000 // 0.01 DOGE
 }

--- a/BlockchainSdk/WalletManagers/Dogecoin/DogecoinWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Dogecoin/DogecoinWalletManager.swift
@@ -7,14 +7,85 @@
 //
 
 import Foundation
+import Combine
+import TangemSdk
 
 class DogecoinWalletManager: BitcoinWalletManager {
     override var minimalFee: Decimal { 0.01 }
     override var minimalFeePerByte: Decimal { 1 }
+    
+    override func getFee(amount: Amount, destination: String) -> AnyPublisher<[Amount], Error> {
+        // https://github.com/dogecoin/dogecoin/blob/master/doc/fee-recommendation.md
+        
+        let dogePerKiloByte: Decimal = 0.01
+        let bytesInKiloByte: Decimal = 1024
+
+        let satoshiPerByte = dogePerKiloByte * wallet.blockchain.decimalValue / bytesInKiloByte
+        let satoshiPerByteInteger = (satoshiPerByte.rounded(roundingMode: .up) as NSDecimalNumber).intValue
+        
+        let transactionSize: Int
+        do {
+            let changeScript = txBuilder.changeScript
+            let hashes = try txBuilder.bitcoinManager.buildForSign(
+                target: destination,
+                amount: amount.value,
+                feeRate: satoshiPerByteInteger,
+                changeScript: changeScript
+            )
+            
+            let signer = DummySigner()
+            let signatures = try hashes.map {
+                try signer.sign(hash: $0, walletPublicKey: signer.publicKey)
+            }
+            
+            let transactionData = try txBuilder.bitcoinManager.buildForSend(
+                target: destination,
+                amount: amount.value,
+                feeRate: satoshiPerByteInteger,
+                derSignatures: signatures,
+                changeScript: changeScript
+            )
+            transactionSize = transactionData.count
+        } catch {
+            print("Failed to calculate \(wallet.blockchain.displayName) fee", error)
+            return .anyFail(error: BlockchainSdkError.failedToLoadFee)
+        }
+        
+        let normalSatoshiFee = Decimal(integerLiteral: satoshiPerByteInteger * transactionSize) / wallet.blockchain.decimalValue
+
+        let minSatoshiFee = normalSatoshiFee * 0.8
+        let maxSatoshiFee = normalSatoshiFee * 1.2
+        
+        let feeAmounts = [minSatoshiFee, normalSatoshiFee, maxSatoshiFee]
+            .map {
+                Amount(with: wallet.blockchain, value: $0)
+            }
+        
+        return Just(feeAmounts)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
 }
 
 extension DogecoinWalletManager: DustRestrictable {
     var dustValue: Amount {
         .init(with: wallet.blockchain, value: minimalFee)
+    }
+}
+
+fileprivate class DummySigner {
+    let privateKey: Data
+    let publicKey: Wallet.PublicKey
+    
+    init() {
+        let keyPair = try! Secp256k1Utils().generateKeyPair()
+        let compressedPublicKey = try! Secp256k1Key(with: keyPair.publicKey).compress()
+        self.publicKey = Wallet.PublicKey(seedKey: compressedPublicKey, derivedKey: nil, derivationPath: nil)
+        self.privateKey = keyPair.privateKey
+    }
+    
+    func sign(hash: Data, walletPublicKey: Wallet.PublicKey) throws -> Data {
+        let signature = try Secp256k1Utils().sign(hash, with: privateKey)
+        return signature
     }
 }

--- a/BlockchainSdk/WalletManagers/Dogecoin/DogecoinWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Dogecoin/DogecoinWalletManager.swift
@@ -54,6 +54,8 @@ class DogecoinWalletManager: BitcoinWalletManager {
         
         let minSatoshiFee = Decimal(integerLiteral: satoshiPerByteInteger * transactionSize) / wallet.blockchain.decimalValue
 
+        // Minimal fee is too small, increase it several times fold to make the transaction confirm faster.
+        // It's still going to be under 1 DOGE
         let normalSatoshiFee = minSatoshiFee * 10
         let maxSatoshiFee = minSatoshiFee * 100
         

--- a/BlockchainSdk/WalletManagers/Dogecoin/DogecoinWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Dogecoin/DogecoinWalletManager.swift
@@ -36,10 +36,8 @@ class DogecoinWalletManager: BitcoinWalletManager {
                 changeScript: changeScript
             )
             
-            let signer = DummySigner()
-            let signatures = try hashes.map {
-                try signer.sign(hash: $0, walletPublicKey: signer.publicKey)
-            }
+            let secpSignatureSize = 64
+            let signatures = hashes.map { _ in Data(repeating: 1, count: secpSignatureSize) }
             
             let transactionData = try txBuilder.bitcoinManager.buildForSend(
                 target: destination,
@@ -73,22 +71,5 @@ class DogecoinWalletManager: BitcoinWalletManager {
 extension DogecoinWalletManager: DustRestrictable {
     var dustValue: Amount {
         .init(with: wallet.blockchain, value: minimalFee)
-    }
-}
-
-fileprivate class DummySigner {
-    let privateKey: Data
-    let publicKey: Wallet.PublicKey
-    
-    init() {
-        let keyPair = try! Secp256k1Utils().generateKeyPair()
-        let compressedPublicKey = try! Secp256k1Key(with: keyPair.publicKey).compress()
-        self.publicKey = Wallet.PublicKey(seedKey: compressedPublicKey, derivedKey: nil, derivationPath: nil)
-        self.privateKey = keyPair.privateKey
-    }
-    
-    func sign(hash: Data, walletPublicKey: Wallet.PublicKey) throws -> Data {
-        let signature = try Secp256k1Utils().sign(hash, with: privateKey)
-        return signature
     }
 }

--- a/BlockchainSdk/WalletManagers/Dogecoin/DogecoinWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Dogecoin/DogecoinWalletManager.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 class DogecoinWalletManager: BitcoinWalletManager {
-    override var minimalFee: Decimal { 1.0 }
+    override var minimalFee: Decimal { 0.01 }
     override var minimalFeePerByte: Decimal { 1 }
 }
 

--- a/BlockchainSdk/WalletManagers/Dogecoin/DogecoinWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Dogecoin/DogecoinWalletManager.swift
@@ -12,15 +12,18 @@ import TangemSdk
 
 class DogecoinWalletManager: BitcoinWalletManager {
     override var minimalFee: Decimal { 0.01 }
-    override var minimalFeePerByte: Decimal { 1 }
+    override var minimalFeePerByte: Decimal {
+        let dogePerKiloByte: Decimal = 0.01
+        let bytesInKiloByte: Decimal = 1024
+        
+        return dogePerKiloByte / bytesInKiloByte
+    }
     
     override func getFee(amount: Amount, destination: String) -> AnyPublisher<[Amount], Error> {
         // https://github.com/dogecoin/dogecoin/blob/master/doc/fee-recommendation.md
         
-        let dogePerKiloByte: Decimal = 0.01
-        let bytesInKiloByte: Decimal = 1024
-
-        let satoshiPerByte = dogePerKiloByte * wallet.blockchain.decimalValue / bytesInKiloByte
+        let satoshiPerByte = minimalFeePerByte * wallet.blockchain.decimalValue
+        
         let satoshiPerByteInteger = (satoshiPerByte.rounded(roundingMode: .up) as NSDecimalNumber).intValue
         
         let transactionSize: Int

--- a/BlockchainSdk/WalletManagers/Dogecoin/DogecoinWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Dogecoin/DogecoinWalletManager.swift
@@ -54,10 +54,10 @@ class DogecoinWalletManager: BitcoinWalletManager {
             return .anyFail(error: BlockchainSdkError.failedToLoadFee)
         }
         
-        let normalSatoshiFee = Decimal(integerLiteral: satoshiPerByteInteger * transactionSize) / wallet.blockchain.decimalValue
+        let minSatoshiFee = Decimal(integerLiteral: satoshiPerByteInteger * transactionSize) / wallet.blockchain.decimalValue
 
-        let minSatoshiFee = normalSatoshiFee * 0.8
-        let maxSatoshiFee = normalSatoshiFee * 1.2
+        let normalSatoshiFee = minSatoshiFee * 10
+        let maxSatoshiFee = minSatoshiFee * 100
         
         let feeAmounts = [minSatoshiFee, normalSatoshiFee, maxSatoshiFee]
             .map {

--- a/BlockchainSdkExample/BlockchainSdkExampleViewModel.swift
+++ b/BlockchainSdkExample/BlockchainSdkExampleViewModel.swift
@@ -59,6 +59,7 @@ class BlockchainSdkExampleViewModel: ObservableObject {
     private let walletManagerFactory = WalletManagerFactory(config: .init(blockchairApiKeys: [],
                                                                           blockcypherTokens: [],
                                                                           infuraProjectId: "",
+                                                                          useBlockBookUtxoApis: true,
                                                                           nowNodesApiKey: "",
                                                                           getBlockApiKey: "",
                                                                           tronGridApiKey: "",


### PR DESCRIPTION
- для биткоина примерно такие же комиссии будут, такого же порядка
- для дожкоина будет значительно меньше. Раньше апишки нам возвращали (1; 1.3, 1.6 DOGE), теперь по стандарту примерно 0.002 (https://github.com/dogecoin/dogecoin/blob/master/doc/fee-recommendation.md)
- для лайткоина не изменилось, везде минимальные значения — 1 копейка за байт
- для равенкоина у новых апишек комиссия за байт (1; 1; 1 копеек), у старых (0; 1; 1) и (11; 17; 24)

Кидал сюда с минимальными комиссиями:
- https://dogechain.info/address/D98cEV9RUE8Tb2y1TajGHUCMSeGcwPeMoB
- https://blockchair.com/bitcoin/address/bc1q66l4wul3l3m3z39hp6e09mnlhmfjwlj6pdfjqj
- https://blockchair.com/dash/address/XhRU6qK1hKooCzLumRgxSMTMCwrTXKkxTQ

Дож и дэш быстро подтверждаются. 

Биткоин висит 4 часа... Биткоин часа через 7 подтвердился с confirmationBlocks=10, feePerByte = 10 satoshi. https://blockchair.com/bitcoin/transaction/5b07117079b1de01807a1ec09ec47b18364578d02e8ed3bddd62bcbf2703ea32

Сделал confirmationBlocks = 8, feePerByte = 12 satoshi. Отправил в 10 МСК, 8 UTC. Подтвердилось через 20-30 минут. В это время recommended transaction fee было 1 satoshi per byte. https://blockchair.com/bitcoin/transaction/86f4948fd14e0924407913a6602248b1212ecfa97180a58d528a9642f98655a2

Тоже confirmationBlock=8, feeperbyte = 12 satoshi. Отправил в 11 МСК, 9 UTC. На момент отправки recommended transaction fee было 19 satoshi per byte. Подтвердилось через минут 50. https://blockchair.com/bitcoin/transaction/e8f778c4e3d7cf58baded6cde112b8552b0b6f11d690bc90cd2dda9da631f3a0

Тоже confirmationBlock=8, feeperbyte = 12 satoshi. Отправил в 12 МСК, 10 UTC. На момент отправки recommended transaction fee было 13 satoshi per byte. Подтвердилось через минут 10.
https://blockchair.com/bitcoin/transaction/b36f9c71f0bffe0b075de9b1bd0a75a241cf17a7dea2b2963781bfe19a7c2ab4