### PR TITLE
IOS-3052: Add missing transaction params

### DIFF
--- a/BlockchainSdk/WalletManagers/Optimism/OptimismWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Optimism/OptimismWalletManager.swift
@@ -71,13 +71,14 @@ class OptimismWalletManager: EthereumWalletManager {
     
     override func sign(_ transaction: Transaction, signer: TransactionSigner) -> AnyPublisher<String, Error> {
         let calculatedTransactionFee = transaction.fee.value - (lastLayer1FeeAmount?.value ?? 0)
-        guard let transactionWithCorrectFee = try? createTransaction(amount: transaction.amount,
+        guard var transactionWithCorrectFee = try? createTransaction(amount: transaction.amount,
                                                                      fee: Amount(with: wallet.blockchain, value: calculatedTransactionFee),
                                                                      destinationAddress: transaction.destinationAddress)
         else {
             return Fail(error: WalletError.failedToBuildTx).eraseToAnyPublisher()
         }
         
+        transactionWithCorrectFee.params = transaction.params
         return super.sign(transactionWithCorrectFee, signer: signer)
     }
 }


### PR DESCRIPTION
при перерасчете фи терялись дополнительные параметры, а в них хранится нонс, лимит газа и дата для обработки смарт-контрактом