### PR TITLE
IOS-3214 add cell fee from service and aproximate

### DIFF
--- a/BlockchainSdk/BlockchainService/TON/TONNetworkService.swift
+++ b/BlockchainSdk/BlockchainService/TON/TONNetworkService.swift
@@ -60,8 +60,10 @@ class TONNetworkService: MultiNetworkProvider {
                         throw WalletError.empty
                     }
                     
-                    let fee = fee.sourceFees.totalFee / self.blockchain.decimalValue
-                    return [Amount(with: self.blockchain, value: fee)]
+                    /// Make rounded digits by correct for max amount Fee
+                    let sourceFee = NSDecimalNumber(decimal: fee.sourceFees.totalFee / self.blockchain.decimalValue).doubleValue
+                    let roundedValue = ceil(sourceFee * 100) / 100.0
+                    return [Amount(with: self.blockchain, value: Decimal(roundedValue))]
                 }
                 .eraseToAnyPublisher()
         }

--- a/BlockchainSdk/BlockchainService/TON/TONNetworkService.swift
+++ b/BlockchainSdk/BlockchainService/TON/TONNetworkService.swift
@@ -61,9 +61,9 @@ class TONNetworkService: MultiNetworkProvider {
                     }
                     
                     /// Make rounded digits by correct for max amount Fee
-                    let sourceFee = NSDecimalNumber(decimal: fee.sourceFees.totalFee / self.blockchain.decimalValue).doubleValue
-                    let roundedValue = ceil(sourceFee * 100) / 100.0
-                    return [Amount(with: self.blockchain, value: Decimal(roundedValue))]
+                    let fee = fee.sourceFees.totalFee / self.blockchain.decimalValue
+                    let roundedValue = fee.rounded(scale: 2, roundingMode: .up)
+                    return [Amount(with: self.blockchain, value: roundedValue)]
                 }
                 .eraseToAnyPublisher()
         }

--- a/BlockchainSdk/Common/Blockchain.swift
+++ b/BlockchainSdk/Common/Blockchain.swift
@@ -247,7 +247,7 @@ public enum Blockchain: Equatable, Hashable {
     
     public func isFeeApproximate(for amountType: Amount.AmountType) -> Bool {
         switch self {
-        case .arbitrum, .stellar, .optimism, .ethereumPoW:
+        case .arbitrum, .stellar, .optimism, .ethereumPoW, .ton:
             return true
         case .fantom, .tron, .gnosis, .avalanche:
             if case .token = amountType {


### PR DESCRIPTION
Пришлось сделать апроксимацию и округление, потому что согласно документации, на момент собранной транзакции к отправке, точное значение комиссии не известно

`_Fees on TON are difficult to calculate in advance, as their amount depends on transaction run time, account status, message content and size, blockchain network settings, and a number of other variables that cannot be calculated until the transaction is sent._`