### PR TITLE
IOS-3253 Add right prefix for TON coin display name

### DIFF
--- a/BlockchainSdk/Common/Blockchain.swift
+++ b/BlockchainSdk/Common/Blockchain.swift
@@ -211,6 +211,8 @@ public enum Blockchain: Equatable, Hashable {
             return "Optimistic Ethereum" + testnetSuffix
         case .saltPay:
             return "Salt Pay"
+        case .ton:
+            return "Toncoin" + testnetSuffix
         default:
             var name = "\(self)".capitalizingFirstLetter()
             if let index = name.firstIndex(of: "(") {


### PR DESCRIPTION
Поправил displayName для ТОНа в рамках задачи https://tangem.atlassian.net/browse/IOS-3253. В основном приложении проверил отображается по требованиям.