### PR TITLE
IOS-3386 Allow fee selection for cosmos. Throwing errors produced by external signer.

### DIFF
--- a/BlockchainSdk/WalletManagers/Cosmos/CosmosWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Cosmos/CosmosWalletManager.swift
@@ -12,7 +12,7 @@ import WalletCore
 
 class CosmosWalletManager: BaseManager, WalletManager {
     var currentHost: String { networkService.host }
-    var allowsFeeSelection: Bool { false }
+    var allowsFeeSelection: Bool { true }
     
     var networkService: CosmosNetworkService!
     var txBuilder: CosmosTransactionBuilder!
@@ -65,6 +65,10 @@ class CosmosWalletManager: BaseManager, WalletManager {
                 
                 let signer = WalletCoreSigner(sdkSigner: signer, walletPublicKey: self.wallet.publicKey, curve: self.cosmosChain.blockchain.curve)
                 let output: CosmosSigningOutput = AnySigner.signExternally(input: input, coin: self.cosmosChain.coin, signer: signer)
+                
+                if let error = signer.error {
+                    throw error
+                }
                 
                 guard let outputData = output.serialized.data(using: .utf8) else {
                     throw WalletError.failedToGetFee


### PR DESCRIPTION
Копия этого МРа с подписью коммитов: https://github.com/tangem/blockchain-sdk-swift/pull/298

