### PR TITLE
IOS-3931: Add public initializers for Wallet and Wallet.PublicKey.Derivation

### DIFF
--- a/BlockchainSdk/Common/Wallet+PublicKey.swift
+++ b/BlockchainSdk/Common/Wallet+PublicKey.swift
@@ -38,5 +38,10 @@ extension Wallet.PublicKey {
     public struct Derivation: Codable, Hashable {
         let path: DerivationPath
         let derivedKey: ExtendedPublicKey
+
+        public init(path: DerivationPath, derivedKey: ExtendedPublicKey) {
+            self.path = path
+            self.derivedKey = derivedKey
+        }
     }
 }

--- a/BlockchainSdk/Common/Wallet.swift
+++ b/BlockchainSdk/Common/Wallet.swift
@@ -69,7 +69,12 @@ public struct Wallet {
             .compactMapValues { $0.publicKey.xpubKey(isTestnet: blockchain.isTestnet) }
             .map { $0.value }
     }
-    
+
+    public init(blockchain: Blockchain, addresses: [AddressType: Address]) {
+        self.blockchain = blockchain
+        self.walletAddresses = addresses
+    }
+
     @available(*, deprecated, message: "Use init(blockchain:, addresses:)")
     init(blockchain: Blockchain, addresses: [Address], publicKey: PublicKey) {
         self.blockchain = blockchain
@@ -80,11 +85,6 @@ public struct Wallet {
         
         assert(addresses.contains { $0.key == .default }, "Addresses have to contains default address")
 
-        self.walletAddresses = addresses
-    }
-    
-    init(blockchain: Blockchain, addresses: [AddressType: Address]) {
-        self.blockchain = blockchain
         self.walletAddresses = addresses
     }
     


### PR DESCRIPTION
Эти правки нужны чтобы можно было создавать фейковые реализации `WalletManager` в приложении и можно было спокойно работать с превьюхами. В дальнейшем думаю пригодится и для юнит-тестов