### PR TITLE
Fix XRP Base58 decoding

### DIFF
--- a/BlockchainSdk.xcodeproj/project.pbxproj
+++ b/BlockchainSdk.xcodeproj/project.pbxproj
@@ -277,6 +277,7 @@
 		DAF0866E27A942D60024312E /* PolkadotWalletManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF0866D27A942D60024312E /* PolkadotWalletManager.swift */; };
 		DAF0867027A9438C0024312E /* PolkadotNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF0866F27A9438C0024312E /* PolkadotNetworkService.swift */; };
 		DAF3AD4629E916D300E057FA /* CosmosFeeParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF3AD4529E916D300E057FA /* CosmosFeeParameters.swift */; };
+		DC173AEC2A5D42EE0088F79E /* XRPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC173AEB2A5D42EE0088F79E /* XRPTests.swift */; };
 		DC4E442B29BF4B4C0088617C /* XRPBase58.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4E442A29BF4B4C0088617C /* XRPBase58.swift */; };
 		DC63F266293F243200F953EF /* Credentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC63F265293F243200F953EF /* Credentials.swift */; };
 		E93532CE292D0E86008FD979 /* BlockBookUtxoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9941ACA2927B07300399DE3 /* BlockBookUtxoProvider.swift */; };
@@ -678,6 +679,7 @@
 		DAF0866D27A942D60024312E /* PolkadotWalletManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PolkadotWalletManager.swift; sourceTree = "<group>"; };
 		DAF0866F27A9438C0024312E /* PolkadotNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolkadotNetworkService.swift; sourceTree = "<group>"; };
 		DAF3AD4529E916D300E057FA /* CosmosFeeParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CosmosFeeParameters.swift; sourceTree = "<group>"; };
+		DC173AEB2A5D42EE0088F79E /* XRPTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XRPTests.swift; sourceTree = "<group>"; };
 		DC4E442A29BF4B4C0088617C /* XRPBase58.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XRPBase58.swift; sourceTree = "<group>"; };
 		DC63F265293F243200F953EF /* Credentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Credentials.swift; sourceTree = "<group>"; };
 		DCE3379A28F2B7260029A6F5 /* BlockchainSdkExample.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = BlockchainSdkExample.entitlements; sourceTree = "<group>"; };
@@ -915,6 +917,7 @@
 		5D14E47B2397B80F00C15FC8 /* BlockchainSdkTests */ = {
 			isa = PBXGroup;
 			children = (
+				DC173AEA2A5D42D40088F79E /* XRP */,
 				2D535E7A2A0CC5FA0081EB76 /* Vectors */,
 				2D535E7E2A0CC5FA0081EB76 /* VectorTests */,
 				B00DEAC728FEE5E00077CD19 /* Bitcoin */,
@@ -1707,6 +1710,14 @@
 			path = Polkadot;
 			sourceTree = "<group>";
 		};
+		DC173AEA2A5D42D40088F79E /* XRP */ = {
+			isa = PBXGroup;
+			children = (
+				DC173AEB2A5D42EE0088F79E /* XRPTests.swift */,
+			);
+			path = XRP;
+			sourceTree = "<group>";
+		};
 		E9941AC72927845C00399DE3 /* BlockBook */ = {
 			isa = PBXGroup;
 			children = (
@@ -2451,6 +2462,7 @@
 				DA63B08D29CB3FAF00AC6E49 /* KaspaTests.swift in Sources */,
 				2DBBE95029C8DBEA00971539 /* TONTests.swift in Sources */,
 				2D535E782A0CC5E50081EB76 /* KeysServiceManagerUtility.swift in Sources */,
+				DC173AEC2A5D42EE0088F79E /* XRPTests.swift in Sources */,
 				2D535E872A0CC5FA0081EB76 /* AddressesValidationTests.swift in Sources */,
 				EF0DA78928523FAC0081092A /* LitecoinTests.swift in Sources */,
 				EF0DA78828523FAC0081092A /* BitcoinTests.swift in Sources */,

--- a/BlockchainSdk/Extensions/Data+.swift
+++ b/BlockchainSdk/Extensions/Data+.swift
@@ -35,4 +35,11 @@ extension Data {
     func validateAsSecp256k1Key() throws {
         _ = try Secp256k1Key(with: self)
     }
+
+    func leadingZeroPadding(toLength newLength: Int) -> Data {
+        guard count < newLength else { return self }
+
+        let prefix = Data(repeating: UInt8(0), count: newLength - count)
+        return prefix + self
+    }
 }

--- a/BlockchainSdk/WalletManagers/XRP/XRPKit/Sources/XRPKit/Utilities/Serializer.swift
+++ b/BlockchainSdk/WalletManagers/XRP/XRPKit/Sources/XRPKit/Utilities/Serializer.swift
@@ -167,15 +167,10 @@ class Serializer {
     }
     
     private func decodeAddress(address: String) -> Data {
-        let _array = [UInt8](XRPBase58.getData(from: address)!)
-        let array = _array.prefix(_array.count-4)
-        
-        //FIXME: base58Decoding
-        if (array[0] == 0 || array[0] == 114) && array.count == 21 {
-            return Data(array.suffix(from: 1))
-        } else {
-            fatalError()
-        }
+        let decodedData = XRPBase58.getData(from: address)!
+        let decodedDataWithoutCheksum = Data(decodedData.dropLast(4))
+        let accountId = decodedDataWithoutCheksum.leadingZeroPadding(toLength: 20)
+        return accountId
     }
     
     private func accountIDToBytes(address: String) -> Data {

--- a/BlockchainSdk/WalletManagers/XRP/XRPKit/XRPBase58.swift
+++ b/BlockchainSdk/WalletManagers/XRP/XRPKit/XRPBase58.swift
@@ -12,10 +12,12 @@ import BigInt
 enum XRPBase58 {
     fileprivate static let xrpAlphabet = [UInt8]("rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz".utf8)
 
+    /// returns string preserving leading zeroes
     static func getString(from data: Data) -> String {
         return String(base58: data, alphabet: XRPBase58.xrpAlphabet)
     }
 
+    /// returns data with stripped zeroes
     static func getData(from string: String) -> Data? {
         return Data(base58: string, alphabet: XRPBase58.xrpAlphabet)
     }
@@ -60,6 +62,6 @@ fileprivate extension Data {
         }
 
         let bytes = answer.serialize()
-        self = byteString.prefix(while: { i in i == alphabet[0]}) + bytes
+        self = bytes
     }
 }

--- a/BlockchainSdk/WalletManagers/XRP/XRPTransactionBuilder.swift
+++ b/BlockchainSdk/WalletManagers/XRP/XRPTransactionBuilder.swift
@@ -9,6 +9,7 @@
 import Foundation
 import TangemSdk
 
+/// XRP transactions decoder https://fluxw42.github.io/ripple-tx-decoder/
 class XRPTransactionBuilder {
     var account: String? = nil
     var sequence: Int? = nil

--- a/BlockchainSdkTests/XRP/XRPTests.swift
+++ b/BlockchainSdkTests/XRP/XRPTests.swift
@@ -1,0 +1,55 @@
+//
+//  XRPTests.swift
+//  BlockchainSdkTests
+//
+//  Created by Alexander Osokin on 11.07.2023.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+import XCTest
+import Combine
+import CryptoKit
+
+@testable import BlockchainSdk
+
+class XRPTests: XCTestCase {
+    func testRoundTripAccountWithDoubleRBase58Encoding() {
+        // simulate address with double r
+        let buffer = Data(hexString: "000010101010101010101010101010101010101010")
+        let checkSum = buffer.getDoubleSha256().prefix(4)
+        let account = XRPBase58.getString(from: buffer + checkSum)
+        let decodedData = XRPBase58.getData(from: account)!
+        // 1 zero byte for network prefix + 20 bytes of address data + 4 bytes of checksum
+        let accountData = decodedData.leadingZeroPadding(toLength: 25)
+        let accountString = XRPBase58.getString(from: accountData)
+        XCTAssertEqual(account, accountString)
+    }
+
+    func testAcccountIntoTxEncoding() {
+        let account = "rrpCDJ3yxMGC1XPfg1iMRVwsg8a8rar4fa"
+
+        let fields: [String:Any] = [
+            "Account" : account
+        ]
+
+        let tx = XRPTransaction(fields: fields)
+        let blob = tx.getBlob()
+        XCTAssertEqual(blob, "81140050505050505050505050505050505050505050")
+    }
+
+    func testXAddressEncode() throws {
+        let rAddress = "rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf"
+        let tag = 4294967294
+
+        let xrpAddress = try XRPAddress(rAddress: rAddress, tag: UInt32(tag))
+        XCTAssertEqual(xrpAddress.rAddress, "rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
+        XCTAssertEqual(xrpAddress.xAddress, "XVLhHMPHU98es4dbozjVtdWzVrDjtV1kAsixQTdMjbWi39u")
+
+        let xrpAddress2 = try XRPAddress(xAddress: "XVLhHMPHU98es4dbozjVtdWzVrDjtV1kAsixQTdMjbWi39u")
+        XCTAssertEqual(xrpAddress2.rAddress, "rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf")
+        XCTAssertEqual(xrpAddress2.xAddress, "XVLhHMPHU98es4dbozjVtdWzVrDjtV1kAsixQTdMjbWi39u")
+        XCTAssertEqual(xrpAddress2.tag, 4294967294)
+    }
+}

--- a/BlockchainSdkTests/XRP/XRPTests.swift
+++ b/BlockchainSdkTests/XRP/XRPTests.swift
@@ -30,13 +30,19 @@ class XRPTests: XCTestCase {
     func testAcccountIntoTxEncoding() {
         let account = "rrpCDJ3yxMGC1XPfg1iMRVwsg8a8rar4fa"
 
-        let fields: [String:Any] = [
-            "Account" : account
+        let fieldsWithAccount: [String:Any] = [
+            "Account" : account,
         ]
 
-        let tx = XRPTransaction(fields: fields)
-        let blob = tx.getBlob()
-        XCTAssertEqual(blob, "81140050505050505050505050505050505050505050")
+        let blobAccount = XRPTransaction(fields: fieldsWithAccount).getBlob()
+        XCTAssertEqual(blobAccount, "81140050505050505050505050505050505050505050")
+
+        let fieldsWithDestination: [String:Any] = [
+            "Destination" : account,
+        ]
+
+        let blobDestination = XRPTransaction(fields: fieldsWithDestination).getBlob()
+        XCTAssertEqual(blobDestination, "83140050505050505050505050505050505050505050")
     }
 
     func testXAddressEncode() throws {


### PR DESCRIPTION
Проблема была в неправильной реализации декодирования из base58 строки. Не обрезались лидирующие нули, поэтому в транзакцию попадал неправильно перекодированный адрес. Воспроизводилось только для адресов, начинающихся с rr. R соответствует 0 в base58 алфавите XRP. Первая будква r добавляется всегда, она хэндлилась нормально и отрезалась искусственно, а вторая - нет. Теперь сколько бы r не было в начале, все будут заменены на 0

Весь затронутый код покрывается юнитами. То что не используется я удалил, чтобы не заморачиваться проверками.