### PR TITLE
IOS-4217: Replace discontinued Ethercluster ETC API

### DIFF
--- a/BlockchainSdk/Common/Blockchain.swift
+++ b/BlockchainSdk/Common/Blockchain.swift
@@ -368,12 +368,12 @@ extension Blockchain {
         case .ethereumClassic:
             if isTestnet {
                 return [
-                    URL(string: "https://www.ethercluster.com/kotti")!,
+                    URL(string: "https://etc.rivet.link/kotti")!,
                 ]
             } else {
                 return [
                     URL(string: "https://etc.getblock.io/mainnet?api_key=\(getBlockApiKey)")!,
-                    URL(string: "https://www.ethercluster.com/etc")!,
+                    URL(string: "https://etc.rivet.link/etc")!,
                     URL(string: "https://etc.etcdesktop.com")!,
                     URL(string: "https://blockscout.com/etc/mainnet/api/eth-rpc")!,
                     URL(string: "https://etc.mytokenpocket.vip")!,


### PR DESCRIPTION
[IOS-4217](https://tangem.atlassian.net/browse/IOS-4217)

[IOS-4217]: https://tangem.atlassian.net/browse/IOS-4217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ