### PR TITLE
IOS-4366 Update EthereumWalletManager.swift

### DIFF
--- a/BlockchainSdk/WalletManagers/Ethereum/EthereumWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Ethereum/EthereumWalletManager.swift
@@ -100,6 +100,8 @@ private extension EthereumWalletManager {
                 let gasLimit = ethereumFeeResponse.gasLimit
                 let fees = ethereumFeeResponse.gasPrices.map { gasPrice in
                     let feeValue = gasLimit * gasPrice
+                    // TODO: Fix integer overflow. Think about BigInt
+                    // https://tangem.atlassian.net/browse/IOS-4268
                     let fee = Decimal(Int(feeValue)) / self.wallet.blockchain.decimalValue
 
                     let amount = Amount(with: self.wallet.blockchain, value: fee)

--- a/BlockchainSdk/WalletManagers/Ethereum/EthereumWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Ethereum/EthereumWalletManager.swift
@@ -100,7 +100,7 @@ private extension EthereumWalletManager {
                 let gasLimit = ethereumFeeResponse.gasLimit
                 let fees = ethereumFeeResponse.gasPrices.map { gasPrice in
                     let feeValue = gasLimit * gasPrice
-                    let fee = Decimal(Double(feeValue)) / self.wallet.blockchain.decimalValue
+                    let fee = Decimal(Int(feeValue)) / self.wallet.blockchain.decimalValue
 
                     let amount = Amount(with: self.wallet.blockchain, value: fee)
                     let parameters = EthereumFeeParameters(gasLimit: gasLimit, gasPrice: gasPrice)


### PR DESCRIPTION
- Предлагаю вообще запретить `Double`
- Была проблема в том, что после умножения мы получаем число 
GasPrice * GasLimit = 2188208784908999 (16 symbols) 
2188208784908999936 = Decimal(Double(2188208784908999) // тут косяк
и после деления 0.002188208784908999936
и в итоге при переводе в bigUIntValue у нас возвращался nil, так как звонов после запятой было 21, а мы указывали 18