### PR TITLE
IOS-4375: Add EVM Blockchains into NowNodesBlockBookConfig

### DIFF
--- a/BlockchainSdk.xcodeproj/project.pbxproj
+++ b/BlockchainSdk.xcodeproj/project.pbxproj
@@ -353,6 +353,7 @@
 		EF9F9086299F88D1006F638F /* EthereumWalletManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF9F9085299F88D1006F638F /* EthereumWalletManager.swift */; };
 		EF9F9088299F8B70006F638F /* ETHError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF9F9087299F8B70006F638F /* ETHError.swift */; };
 		EFAD40A72A9756A200364D65 /* CardanoResponseMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFAD40A62A9756A200364D65 /* CardanoResponseMapper.swift */; };
+		EFAD40A52A965BA800364D65 /* BlockBookNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFAD40A42A965BA800364D65 /* BlockBookNode.swift */; };
 		EFB9523D2A6FDB2A00996D16 /* TransactionHistoryProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB9523C2A6FDB2A00996D16 /* TransactionHistoryProvider.swift */; };
 		EFB952402A6FEF1700996D16 /* TransactionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB9523F2A6FEF1700996D16 /* TransactionRecord.swift */; };
 		EFB952422A6FF30B00996D16 /* BlockscoutResponseMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB952412A6FF30B00996D16 /* BlockscoutResponseMapper.swift */; };
@@ -774,6 +775,7 @@
 		EF9F9085299F88D1006F638F /* EthereumWalletManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EthereumWalletManager.swift; sourceTree = "<group>"; };
 		EF9F9087299F8B70006F638F /* ETHError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ETHError.swift; sourceTree = "<group>"; };
 		EFAD40A62A9756A200364D65 /* CardanoResponseMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardanoResponseMapper.swift; sourceTree = "<group>"; };
+		EFAD40A42A965BA800364D65 /* BlockBookNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockBookNode.swift; sourceTree = "<group>"; };
 		EFB9523C2A6FDB2A00996D16 /* TransactionHistoryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistoryProvider.swift; sourceTree = "<group>"; };
 		EFB9523F2A6FEF1700996D16 /* TransactionRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionRecord.swift; sourceTree = "<group>"; };
 		EFB952412A6FF30B00996D16 /* BlockscoutResponseMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockscoutResponseMapper.swift; sourceTree = "<group>"; };
@@ -1739,6 +1741,7 @@
 			children = (
 				DA18C4A7297AC62600EC4C05 /* Implementations */,
 				DA656FC52952091A0092CC61 /* BlockBookConfig.swift */,
+				EFAD40A42A965BA800364D65 /* BlockBookNode.swift */,
 			);
 			path = Config;
 			sourceTree = "<group>";
@@ -2545,6 +2548,7 @@
 				2DA13A072A8AD83B00E3C374 /* ChiaNetworkService.swift in Sources */,
 				5DEAFA8E244472CD0032E316 /* Amount.swift in Sources */,
 				2D9A91A729BB8C2E00476EA6 /* WalletCoreAddressService.swift in Sources */,
+				EFAD40A52A965BA800364D65 /* BlockBookNode.swift in Sources */,
 				2D9A91A729BB8C2E00476EA6 /* WalletCoreAddressService.swift in Sources */,
 				DA9F76FB27ECA49F00F0665C /* TronNetwork.swift in Sources */,
 				EF2BC62029DACE33003D3F18 /* RavencoinTarget.swift in Sources */,

--- a/BlockchainSdk/BlockchainService/BlockBook/BlockBookTarget.swift
+++ b/BlockchainSdk/BlockchainService/BlockBook/BlockBookTarget.swift
@@ -15,7 +15,12 @@ struct BlockBookTarget: TargetType {
     let blockchain: Blockchain
     
     var baseURL: URL {
-        URL(string: config.domain(for: request, blockchain: blockchain))!
+        switch request {
+        case .fees:
+            return URL(string: config.node(for: blockchain).rpcNode)!
+        default:
+            return URL(string: config.node(for: blockchain).restNode)!
+        }
     }
     
     var path: String {

--- a/BlockchainSdk/BlockchainService/BlockBook/Config/BlockBookConfig.swift
+++ b/BlockchainSdk/BlockchainService/BlockBook/Config/BlockBookConfig.swift
@@ -13,6 +13,11 @@ protocol BlockBookConfig {
     var apiKeyName: String { get }
     var host: String { get }
     
-    func domain(for request: BlockBookTarget.Request, blockchain: Blockchain) -> String
+    func node(for blockchain: Blockchain) -> NodeConfig
     func path(for request: BlockBookTarget.Request) -> String
+}
+
+struct NodeConfig {
+    let rpcNode: String
+    let restNode: String
 }

--- a/BlockchainSdk/BlockchainService/BlockBook/Config/BlockBookConfig.swift
+++ b/BlockchainSdk/BlockchainService/BlockBook/Config/BlockBookConfig.swift
@@ -13,11 +13,6 @@ protocol BlockBookConfig {
     var apiKeyName: String { get }
     var host: String { get }
     
-    func node(for blockchain: Blockchain) -> NodeConfig
+    func node(for blockchain: Blockchain) -> BlockBookNode
     func path(for request: BlockBookTarget.Request) -> String
-}
-
-struct NodeConfig {
-    let rpcNode: String
-    let restNode: String
 }

--- a/BlockchainSdk/BlockchainService/BlockBook/Config/BlockBookNode.swift
+++ b/BlockchainSdk/BlockchainService/BlockBook/Config/BlockBookNode.swift
@@ -1,0 +1,14 @@
+//
+//  BlockBookNode.swift
+//  BlockchainSdk
+//
+//  Created by Sergey Balashov on 23.08.2023.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+struct BlockBookNode {
+    let rpcNode: String
+    let restNode: String
+}

--- a/BlockchainSdk/BlockchainService/BlockBook/Config/Implementations/GetBlockBlockBookConfig.swift
+++ b/BlockchainSdk/BlockchainService/BlockBook/Config/Implementations/GetBlockBlockBookConfig.swift
@@ -29,15 +29,13 @@ extension GetBlockBlockBookConfig: BlockBookConfig {
         return "getblock.io"
     }
     
-    func domain(for request: BlockBookTarget.Request, blockchain: Blockchain) -> String {
+    func node(for blockchain: Blockchain) -> NodeConfig {
         let currencySymbolPrefix = blockchain.currencySymbol.lowercased()
         
-        switch request {
-        case .fees:
-            return "https://\(currencySymbolPrefix).\(host)"
-        default:
-            return "https://\(currencySymbolPrefix).\(host)"
-        }
+        return NodeConfig(
+            rpcNode: "https://\(currencySymbolPrefix).\(host)",
+            restNode: "https://\(currencySymbolPrefix).\(host)"
+        )
     }
     
     func path(for request: BlockBookTarget.Request) -> String {

--- a/BlockchainSdk/BlockchainService/BlockBook/Config/Implementations/GetBlockBlockBookConfig.swift
+++ b/BlockchainSdk/BlockchainService/BlockBook/Config/Implementations/GetBlockBlockBookConfig.swift
@@ -29,10 +29,10 @@ extension GetBlockBlockBookConfig: BlockBookConfig {
         return "getblock.io"
     }
     
-    func node(for blockchain: Blockchain) -> NodeConfig {
+    func node(for blockchain: Blockchain) -> BlockBookNode {
         let currencySymbolPrefix = blockchain.currencySymbol.lowercased()
         
-        return NodeConfig(
+        return BlockBookNode(
             rpcNode: "https://\(currencySymbolPrefix).\(host)",
             restNode: "https://\(currencySymbolPrefix).\(host)"
         )

--- a/BlockchainSdk/BlockchainService/BlockBook/Config/Implementations/NowNodesBlockBookConfig.swift
+++ b/BlockchainSdk/BlockchainService/BlockBook/Config/Implementations/NowNodesBlockBookConfig.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+// https://nownodes.io/nodes
 struct NowNodesBlockBookConfig {
     private let apiKey: String
     
@@ -29,15 +30,27 @@ extension NowNodesBlockBookConfig: BlockBookConfig {
         return "nownodes.io"
     }
     
-    func domain(for request: BlockBookTarget.Request, blockchain: Blockchain) -> String {
-        let currencySymbolPrefix = blockchain.currencySymbol.lowercased()
+    func node(for blockchain: Blockchain) -> NodeConfig {
+        var currencySymbolPrefix = blockchain.currencySymbol.lowercased()
         
-        switch request {
-        case .fees:
-            return "https://\(currencySymbolPrefix).\(host)"
-        default:
+        switch blockchain {
+        case .bitcoin, .dash, .dogecoin, .litecoin:
             let testnetSuffix = blockchain.isTestnet ? "-testnet" : ""
-            return "https://\(currencySymbolPrefix)book\(testnetSuffix).\(host)"
+            return NodeConfig(
+                rpcNode: "https://\(currencySymbolPrefix).\(host)",
+                restNode: "https://\(currencySymbolPrefix)book\(testnetSuffix).\(host)"
+            )
+        case .ethereum, .ethereumPoW, .bsc, .ethereumClassic, .avalanche, .tron, .arbitrum:
+            if case .bsc = blockchain {
+                currencySymbolPrefix = "bsc"
+            }
+            
+            return NodeConfig(
+                rpcNode: "https://\(currencySymbolPrefix).\(host)",
+                restNode: "https://\(currencySymbolPrefix)-blockbook.\(host)"
+            )
+        default:
+            fatalError("NowNodesBlockBookConfig don't support blockchain: \(blockchain.displayName)")
         }
     }
     

--- a/BlockchainSdk/BlockchainService/BlockBook/Config/Implementations/NowNodesBlockBookConfig.swift
+++ b/BlockchainSdk/BlockchainService/BlockBook/Config/Implementations/NowNodesBlockBookConfig.swift
@@ -30,13 +30,13 @@ extension NowNodesBlockBookConfig: BlockBookConfig {
         return "nownodes.io"
     }
     
-    func node(for blockchain: Blockchain) -> NodeConfig {
+    func node(for blockchain: Blockchain) -> BlockBookNode {
         var currencySymbolPrefix = blockchain.currencySymbol.lowercased()
         
         switch blockchain {
         case .bitcoin, .dash, .dogecoin, .litecoin:
             let testnetSuffix = blockchain.isTestnet ? "-testnet" : ""
-            return NodeConfig(
+            return BlockBookNode(
                 rpcNode: "https://\(currencySymbolPrefix).\(host)",
                 restNode: "https://\(currencySymbolPrefix)book\(testnetSuffix).\(host)"
             )
@@ -45,7 +45,7 @@ extension NowNodesBlockBookConfig: BlockBookConfig {
                 currencySymbolPrefix = "bsc"
             }
             
-            return NodeConfig(
+            return BlockBookNode(
                 rpcNode: "https://\(currencySymbolPrefix).\(host)",
                 restNode: "https://\(currencySymbolPrefix)-blockbook.\(host)"
             )

--- a/BlockchainSdk/BlockchainService/BlockBook/Config/Implementations/NowNodesBlockBookConfig.swift
+++ b/BlockchainSdk/BlockchainService/BlockBook/Config/Implementations/NowNodesBlockBookConfig.swift
@@ -31,23 +31,24 @@ extension NowNodesBlockBookConfig: BlockBookConfig {
     }
     
     func node(for blockchain: Blockchain) -> BlockBookNode {
-        var currencySymbolPrefix = blockchain.currencySymbol.lowercased()
+        let prefix = blockchain.currencySymbol.lowercased()
         
         switch blockchain {
         case .bitcoin, .dash, .dogecoin, .litecoin:
             let testnetSuffix = blockchain.isTestnet ? "-testnet" : ""
             return BlockBookNode(
-                rpcNode: "https://\(currencySymbolPrefix).\(host)",
-                restNode: "https://\(currencySymbolPrefix)book\(testnetSuffix).\(host)"
+                rpcNode: "https://\(prefix).\(host)",
+                restNode: "https://\(prefix)book\(testnetSuffix).\(host)"
             )
-        case .ethereum, .ethereumPoW, .bsc, .ethereumClassic, .avalanche, .tron, .arbitrum:
-            if case .bsc = blockchain {
-                currencySymbolPrefix = "bsc"
-            }
-            
+        case .ethereum, .ethereumPoW, .ethereumClassic, .avalanche, .tron, .arbitrum:
             return BlockBookNode(
-                rpcNode: "https://\(currencySymbolPrefix).\(host)",
-                restNode: "https://\(currencySymbolPrefix)-blockbook.\(host)"
+                rpcNode: "https://\(prefix).\(host)",
+                restNode: "https://\(prefix)-blockbook.\(host)"
+            )
+        case .bsc:
+            return BlockBookNode(
+                rpcNode: "https://bsc.\(host)",
+                restNode: "https://bsc-blockbook.\(host)"
             )
         default:
             fatalError("NowNodesBlockBookConfig don't support blockchain: \(blockchain.displayName)")


### PR DESCRIPTION
Для истории транзакций надо использовать REST ноду для EVM блокйчейнов
Сейчас REST нода используется для UTXO, и RPC нода используется только для получения fee в utxo. 
В дальнейшем можно так же использовать RPC ноды для Ethereum, сейчас они захардкожены отдельно

<img width="765" alt="Screenshot 2023-08-24 at 10 13 28" src="https://github.com/tangem/blockchain-sdk-swift/assets/25799680/2b5339f9-7d5b-4574-b65d-c8fc0b8f501c">

Full Node -> RPC Call
Explorer -> Rest API Call

RPC используется сейчас только для fee, и только для UTXO
По факту этот MR ничего не ломает, а только добавляет и определяет логику Full Node/Explorer для EVM блокйченов