### PR TITLE
Ios 4425 failed chia transaction

### DIFF
--- a/BlockchainSdk/WalletManagers/Chia/Common/Chia+Int64.swift
+++ b/BlockchainSdk/WalletManagers/Chia/Common/Chia+Int64.swift
@@ -13,7 +13,8 @@ extension Int64 {
     /// Convert amount value for use in ClvmProgram for serialization
     /// - Returns: Binary data encoded
     var chiaEncoded: Data {
-        let unsafeDataValue = withUnsafeBytes(of: self) { Data($0) }.reversed().drop(while: { $0 == 0x00 })
+        let bigEndianData = withUnsafeBytes(of: self.bigEndian) { Data($0) }
+        let unsafeDataValue = bigEndianData.drop(while: { $0 == 0x00 })
         let serializeValue = BigInt(self).serialize()
         return (unsafeDataValue.first ?? 0x00) >= 0x80 ? serializeValue : serializeValue.dropFirst()
     }

--- a/BlockchainSdk/WalletManagers/Chia/Common/Chia+Int64.swift
+++ b/BlockchainSdk/WalletManagers/Chia/Common/Chia+Int64.swift
@@ -15,6 +15,6 @@ extension Int64 {
     var chiaEncoded: Data {
         let unsafeDataValue = withUnsafeBytes(of: self) { Data($0) }.reversed().drop(while: { $0 == 0x00 })
         let serializeValue = BigInt(self).serialize()
-        return unsafeDataValue.first ?? 0x00 >= 0x80 ? serializeValue : serializeValue.dropFirst()
+        return (unsafeDataValue.first ?? 0x00) >= 0x80 ? serializeValue : serializeValue.dropFirst()
     }
 }

--- a/BlockchainSdk/WalletManagers/Chia/Common/Chia+Int64.swift
+++ b/BlockchainSdk/WalletManagers/Chia/Common/Chia+Int64.swift
@@ -12,6 +12,7 @@ import BigInt
 extension Int64 {
     /// Convert amount value for use in ClvmProgram for serialization
     /// - Returns: Binary data encoded
+    /// For description verify example Int.Type converted: 0..127 == 0x00..0x7F | -128..-1 == 0x80..0xFF
     var chiaEncoded: Data {
         let bigEndianData = withUnsafeBytes(of: self.bigEndian) { Data($0) }
         let unsafeDataValue = bigEndianData.drop(while: { $0 == 0x00 })

--- a/BlockchainSdk/WalletManagers/Chia/Common/Chia+Int64.swift
+++ b/BlockchainSdk/WalletManagers/Chia/Common/Chia+Int64.swift
@@ -7,13 +7,14 @@
 //
 
 import Foundation
+import BigInt
 
 extension Int64 {
     /// Convert amount value for use in ClvmProgram for serialization
     /// - Returns: Binary data encoded
     var chiaEncoded: Data {
-        let data = withUnsafeBytes(of: self) { Data($0) }
-        let result = data.bytes.reversed().drop(while: { $0 == 0x00 })
-        return Data(result)
+        let unsafeDataValue = withUnsafeBytes(of: self) { Data($0) }.reversed().drop(while: { $0 == 0x00 })
+        let serializeValue = BigInt(self).serialize()
+        return unsafeDataValue.first ?? 0x00 >= 0x80 ? serializeValue : serializeValue.dropFirst()
     }
 }

--- a/BlockchainSdkTests/Chia/ChiaTests.swift
+++ b/BlockchainSdkTests/Chia/ChiaTests.swift
@@ -174,12 +174,18 @@ class ChiaTests: XCTestCase {
         let buildToSignResult = try transactionBuilder.buildForSign(transaction: transactionData)
         let signedTransaction = try transactionBuilder.buildToSend(signatures: signatures)
         
-        XCTAssertEqual(buildToSignResult, hashToSignes)
+//        XCTAssertEqual(buildToSignResult, hashToSignes)
         try XCTAssertEqual(jsonEncoder.encode(signedTransaction).hexString, jsonEncoder.encode(expectedSignedTransaction).hexString)
     }
     
     func testSizeTransaction() {
         sizeUtility.testTxSizes(testSignatures)
+    }
+    
+    func testChiaEncoded() {
+        let amountValue: Int64 = 10000000
+        let encodedValue = amountValue.chiaEncoded
+        XCTAssertEqual(encodedValue.hexString, "00989680")
     }
     
 }

--- a/BlockchainSdkTests/Chia/ChiaTests.swift
+++ b/BlockchainSdkTests/Chia/ChiaTests.swift
@@ -182,10 +182,18 @@ class ChiaTests: XCTestCase {
         sizeUtility.testTxSizes(testSignatures)
     }
     
-    func testChiaEncoded() {
+    func testNegativeChiaEncoded() {
         let amountValue: Int64 = 10000000
         let encodedValue = amountValue.chiaEncoded
+        
         XCTAssertEqual(encodedValue.hexString, "00989680")
+    }
+    
+    func testPositiveChiaEncoded() {
+        let amountValue: Int64 = 235834596465
+        let encodedValue = amountValue.chiaEncoded
+        
+        XCTAssertEqual(encodedValue.hexString, "36E8D65C71")
     }
     
 }

--- a/BlockchainSdkTests/Chia/ChiaTests.swift
+++ b/BlockchainSdkTests/Chia/ChiaTests.swift
@@ -174,7 +174,7 @@ class ChiaTests: XCTestCase {
         let buildToSignResult = try transactionBuilder.buildForSign(transaction: transactionData)
         let signedTransaction = try transactionBuilder.buildToSend(signatures: signatures)
         
-//        XCTAssertEqual(buildToSignResult, hashToSignes)
+        XCTAssertEqual(buildToSignResult, hashToSignes)
         try XCTAssertEqual(jsonEncoder.encode(signedTransaction).hexString, jsonEncoder.encode(expectedSignedTransaction).hexString)
     }
     


### PR DESCRIPTION
Согласно багу нужно было изменить кодирование байтов для int64. Особый алгоритм работы обусловлен там, что нужно первый байт в массиве байтов нужно проверять на переполнение, и в случае если переполняется добавлять 00

Алгоритм работы следующей:

- получаем массив байт, в виду того что little endean делаем разворот и дропаем нули
- получаем BigInt
- проверяем первый байт чистим или оставляем нули
