### PR TITLE
IOS-4436 Add `.filterSuccessfulStatusAndRedirectCodes()` to `RosettaNetworkProvider`

### DIFF
--- a/BlockchainSdk/BlockchainService/Rosetta/RosettaNetworkProvider.swift
+++ b/BlockchainSdk/BlockchainService/Rosetta/RosettaNetworkProvider.swift
@@ -73,7 +73,9 @@ class RosettaNetworkProvider: CardanoNetworkProvider {
         ).encode().toHexString()
         
         let submitBody = RosettaSubmitBody(networkIdentifier: .mainNet, signedTransaction: txHex)
-        return provider.requestPublisher(.submitTransaction(baseUrl: rosettaUrl, submitBody: submitBody))
+        return provider
+            .requestPublisher(.submitTransaction(baseUrl: rosettaUrl, submitBody: submitBody))
+            .filterSuccessfulStatusAndRedirectCodes()
             .map(RosettaSubmitResponse.self, using: decoder)
             .eraseError()
             .map { $0.transactionIdentifier.hash ?? "" }
@@ -85,6 +87,7 @@ class RosettaNetworkProvider: CardanoNetworkProvider {
             .requestPublisher(.address(baseUrl: rosettaUrl,
                                        addressBody: RosettaAddressBody(networkIdentifier: .mainNet,
                                                                        accountIdentifier: RosettaAccountIdentifier(address: address))))
+            .filterSuccessfulStatusAndRedirectCodes()
             .map(RosettaBalanceResponse.self, using: decoder)
             .eraseError()
             .eraseToAnyPublisher()
@@ -95,6 +98,7 @@ class RosettaNetworkProvider: CardanoNetworkProvider {
             .requestPublisher(.coins(baseUrl: rosettaUrl,
                                      addressBody: RosettaAddressBody(networkIdentifier: .mainNet,
                                                                      accountIdentifier: RosettaAccountIdentifier(address: address))))
+            .filterSuccessfulStatusAndRedirectCodes()
             .map(RosettaCoinsResponse.self, using: decoder)
             .eraseError()
             .eraseToAnyPublisher()


### PR DESCRIPTION
Не было фильтрации ошибки, по этому API могло не переключиться. Обычно это норм работало, так как по формату body шла Decoding ошибка. QA просто поменяли status code. 