### PR TITLE
Ios 4489 fix switched api send event

### DIFF
--- a/BlockchainSdk/Common/API/MultiNetworkProvider.swift
+++ b/BlockchainSdk/Common/API/MultiNetworkProvider.swift
@@ -66,7 +66,6 @@ extension MultiNetworkProvider {
     
     // NOTE: There also copy of this behaviour in the wild, if you want to update something
     // in the code, don't forget to update also Solano.Swift framework, class NetworkingRouter
-    /// - Returns: Return of tuple value with next host provider and flag did switch api
     private func switchProviderIfNeeded(for errorHost: String) -> String? {
         if errorHost != self.host { // Do not switch the provider, if it was switched already
             return providers[currentProviderIndex].host

--- a/BlockchainSdk/Common/API/MultiNetworkProvider.swift
+++ b/BlockchainSdk/Common/API/MultiNetworkProvider.swift
@@ -29,8 +29,7 @@ extension MultiNetworkProvider {
     var host: String { provider.host }
     
     func providerPublisher<T>(for requestPublisher: @escaping (_ provider: Provider) -> AnyPublisher<T, Error>) -> AnyPublisher<T, Error> {
-        let currentHost = self.host
-        
+        let currentHost = provider.host
         return requestPublisher(provider)
             .catch { [weak self] error -> AnyPublisher<T, Error> in
                 guard let self = self else { return .anyFail(error: error) }

--- a/BlockchainSdk/Common/API/MultiNetworkProvider.swift
+++ b/BlockchainSdk/Common/API/MultiNetworkProvider.swift
@@ -70,9 +70,6 @@ extension MultiNetworkProvider {
     // in the code, don't forget to update also Solano.Swift framework, class NetworkingRouter
     /// - Returns: Return of tuple value with next host provider and flag did switch api
     private func switchProviderIfNeeded(for errorHost: String) -> SwitchedNetworkProviderParams? {
-        print(self.host)
-        print(errorHost)
-        
         if errorHost != self.host { // Do not switch the provider, if it was switched already
             return (providers[currentProviderIndex].host, false)
         }


### PR DESCRIPTION
Исправил переключение АПИ через добавление тюпла, где на выходе параметр следующего хоста, и флаг о том что переключение свершилось. 

Прошлая реализация решала проблему корректной отправки ивентов, но переключение апи работало не совсем корректно, "не учитывало ассинхронность"