### PR TITLE
IOS-3832: count only sent transactions

### DIFF
--- a/BlockchainSdk/WalletManagers/Bitcoin/Network/BlockBookUtxoProvider+BitcoinNetworkProvider.swift
+++ b/BlockchainSdk/WalletManagers/Bitcoin/Network/BlockBookUtxoProvider+BitcoinNetworkProvider.swift
@@ -73,8 +73,13 @@ extension BlockBookUtxoProvider: BitcoinNetworkProvider {
     
     func getSignatureCount(address: String) -> AnyPublisher<Int, Error> {
         addressData(address: address, parameters: addressParameters)
-            .tryMap {
-                $0.txs + $0.unconfirmedTxs
+            .tryMap { response in
+                let outgoingTxsCount = response.transactions?.filter { transaction in
+                    return transaction.vin.contains(where: { inputs in
+                        inputs.addresses.contains(address)
+                    })
+                }.count ?? 0
+                return outgoingTxsCount
             }
             .eraseToAnyPublisher()
     }


### PR DESCRIPTION
Если в инпутах хотя бы 1 раз встречается целевой адрес = транзакция исходящая. Проверил на адресе с 15 транзакциями и 8 исходящими. Все сходится. Регина так и не ответила где-то ещё встречалась ли эта проблема, но вроде только в Note BTC. В остальных местах логика не менялась давно.

Из нюансов, которые мы не учли - мы проверяем только по дефолтному адресу, а значит плашка может не появляться, если в инпутах транзакции будет только легаси адреса. Но эту логику надо менять в отдельно задаче уже, если вообще будем менять