### PR TITLE
IOS-4765 Add PendingTransactionRecord

### DIFF
--- a/BlockchainSdk.xcodeproj/project.pbxproj
+++ b/BlockchainSdk.xcodeproj/project.pbxproj
@@ -421,6 +421,7 @@
 		EFD717DB2A272D1B00E5430D /* PlainAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD717DA2A272D1B00E5430D /* PlainAddress.swift */; };
 		EFD717DF2A27310E00E5430D /* AddressType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD717DE2A27310E00E5430D /* AddressType.swift */; };
 		EFEADBDE2A4D737F00744407 /* SignatureInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFEADBDD2A4D737F00744407 /* SignatureInfo.swift */; };
+		EFF466E82ACD851700ACC3EA /* PendingTransactionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF466E72ACD851700ACC3EA /* PendingTransactionRecord.swift */; };
 		EFF56B3D29C20CCE002B6952 /* SmartContractTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF56B3C29C20CCE002B6952 /* SmartContractTargetType.swift */; };
 		EFF56B4129C30265002B6952 /* EthereumFeeParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF56B4029C30265002B6952 /* EthereumFeeParameters.swift */; };
 /* End PBXBuildFile section */
@@ -889,6 +890,7 @@
 		EFD717DA2A272D1B00E5430D /* PlainAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainAddress.swift; sourceTree = "<group>"; };
 		EFD717DE2A27310E00E5430D /* AddressType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressType.swift; sourceTree = "<group>"; };
 		EFEADBDD2A4D737F00744407 /* SignatureInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignatureInfo.swift; sourceTree = "<group>"; };
+		EFF466E72ACD851700ACC3EA /* PendingTransactionRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTransactionRecord.swift; sourceTree = "<group>"; };
 		EFF56B3C29C20CCE002B6952 /* SmartContractTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartContractTargetType.swift; sourceTree = "<group>"; };
 		EFF56B4029C30265002B6952 /* EthereumFeeParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EthereumFeeParameters.swift; sourceTree = "<group>"; };
 		EFF5BA8329B881440070694A /* OptimismContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimismContract.swift; sourceTree = "<group>"; };
@@ -1218,6 +1220,7 @@
 				EF5F1B9629C9C0500093307B /* Fee.swift */,
 				2DA8AB0C2A433A1000C75D85 /* ExceptionHandler.swift */,
 				EFEADBDD2A4D737F00744407 /* SignatureInfo.swift */,
+				EFF466E72ACD851700ACC3EA /* PendingTransactionRecord.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -2471,6 +2474,7 @@
 				5D4B33D123F7DC7500C93A84 /* BinanceAddressService.swift in Sources */,
 				5D01BCE2243F7F7E0048D1BA /* XrpTarget.swift in Sources */,
 				5D7D242925136254001B9A4F /* XRPLedger.swift in Sources */,
+				EFF466E82ACD851700ACC3EA /* PendingTransactionRecord.swift in Sources */,
 				5DF9151D253DB85500B927DD /* TezosNetworkService.swift in Sources */,
 				5DEAFA9224447D350032E316 /* ThenProcessable.swift in Sources */,
 				2DA13A022A8AD83B00E3C374 /* ChiaNetworkProvider.swift in Sources */,

--- a/BlockchainSdk.xcodeproj/project.pbxproj
+++ b/BlockchainSdk.xcodeproj/project.pbxproj
@@ -422,6 +422,7 @@
 		EFD717DF2A27310E00E5430D /* AddressType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD717DE2A27310E00E5430D /* AddressType.swift */; };
 		EFEADBDE2A4D737F00744407 /* SignatureInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFEADBDD2A4D737F00744407 /* SignatureInfo.swift */; };
 		EFF466E82ACD851700ACC3EA /* PendingTransactionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF466E72ACD851700ACC3EA /* PendingTransactionRecord.swift */; };
+		EFF466EF2ACECF8000ACC3EA /* PendingTransactionRecordMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF466EE2ACECF8000ACC3EA /* PendingTransactionRecordMapper.swift */; };
 		EFF56B3D29C20CCE002B6952 /* SmartContractTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF56B3C29C20CCE002B6952 /* SmartContractTargetType.swift */; };
 		EFF56B4129C30265002B6952 /* EthereumFeeParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF56B4029C30265002B6952 /* EthereumFeeParameters.swift */; };
 /* End PBXBuildFile section */
@@ -891,6 +892,7 @@
 		EFD717DE2A27310E00E5430D /* AddressType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressType.swift; sourceTree = "<group>"; };
 		EFEADBDD2A4D737F00744407 /* SignatureInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignatureInfo.swift; sourceTree = "<group>"; };
 		EFF466E72ACD851700ACC3EA /* PendingTransactionRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTransactionRecord.swift; sourceTree = "<group>"; };
+		EFF466EE2ACECF8000ACC3EA /* PendingTransactionRecordMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTransactionRecordMapper.swift; sourceTree = "<group>"; };
 		EFF56B3C29C20CCE002B6952 /* SmartContractTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartContractTargetType.swift; sourceTree = "<group>"; };
 		EFF56B4029C30265002B6952 /* EthereumFeeParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EthereumFeeParameters.swift; sourceTree = "<group>"; };
 		EFF5BA8329B881440070694A /* OptimismContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimismContract.swift; sourceTree = "<group>"; };
@@ -1221,6 +1223,7 @@
 				2DA8AB0C2A433A1000C75D85 /* ExceptionHandler.swift */,
 				EFEADBDD2A4D737F00744407 /* SignatureInfo.swift */,
 				EFF466E72ACD851700ACC3EA /* PendingTransactionRecord.swift */,
+				EFF466EE2ACECF8000ACC3EA /* PendingTransactionRecordMapper.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -2692,6 +2695,7 @@
 				EF3B19182AA5CDF70084AA1C /* BitcoinExternalLinkProvider.swift in Sources */,
 				DA198B6529E44D2600DB6EEA /* CosmosChain.swift in Sources */,
 				EFBE76912A7C066C00CD918B /* TransactionHistoryProviderFactory.swift in Sources */,
+				EFF466EF2ACECF8000ACC3EA /* PendingTransactionRecordMapper.swift in Sources */,
 				5D8653FA23A8C481000DE52D /* StellarNetworkService.swift in Sources */,
 				DC63F266293F243200F953EF /* Credentials.swift in Sources */,
 				5D7D242F25136254001B9A4F /* XRPTransaction.swift in Sources */,

--- a/BlockchainSdk/Common/BaseManager.swift
+++ b/BlockchainSdk/Common/BaseManager.swift
@@ -126,9 +126,7 @@ extension BaseManager: TransactionCreator {
         sourceAddress: String? = nil,
         destinationAddress: String,
         changeAddress: String? = nil,
-        contractAddress: String? = nil,
-        date: Date = Date(),
-        status: TransactionStatus = .unconfirmed
+        contractAddress: String? = nil
     ) throws -> Transaction {
         let transaction = Transaction(
             amount: amount,
@@ -136,10 +134,7 @@ extension BaseManager: TransactionCreator {
             sourceAddress: sourceAddress ?? defaultSourceAddress,
             destinationAddress: destinationAddress,
             changeAddress: changeAddress ?? defaultChangeAddress,
-            contractAddress: contractAddress ?? amount.type.token?.contractAddress,
-            date: date,
-            status: status,
-            hash: nil
+            contractAddress: contractAddress ?? amount.type.token?.contractAddress
         )
         
         try validateTransaction(amount: amount, fee: fee)

--- a/BlockchainSdk/Common/PendingTransactionRecord.swift
+++ b/BlockchainSdk/Common/PendingTransactionRecord.swift
@@ -42,31 +42,3 @@ public struct PendingTransactionRecord {
         self.transactionParams = transactionParams
     }
 }
-
-struct PendingTransactionRecordMapper {
-    func makeDummy(blockchain: Blockchain) -> PendingTransactionRecord {
-        PendingTransactionRecord(
-            hash: .unknown,
-            source: .unknown,
-            destination: .unknown,
-            amount: .zeroCoin(for: blockchain),
-            fee: Fee(.zeroCoin(for: blockchain)),
-            date: Date(),
-            isIncoming: false,
-            transactionParams: nil
-        )
-    }
-    
-    func mapToPendingTransactionRecord(_ pendingTransaction: PendingTransaction, blockchain: Blockchain) -> PendingTransactionRecord {
-        PendingTransactionRecord(
-            hash: pendingTransaction.hash,
-            source: pendingTransaction.source,
-            destination: pendingTransaction.destination,
-            amount: Amount(with: blockchain, value: pendingTransaction.value),
-            fee: Fee(Amount(with: blockchain, value: pendingTransaction.fee ?? 0)),
-            date: pendingTransaction.date,
-            isIncoming: pendingTransaction.isIncoming,
-            transactionParams: pendingTransaction.transactionParams
-        )
-    }
-}

--- a/BlockchainSdk/Common/PendingTransactionRecord.swift
+++ b/BlockchainSdk/Common/PendingTransactionRecord.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-/// Use it in the `Wallet`model like a pending transaction which
 public struct PendingTransactionRecord {
     public let hash: String
     public let source: String

--- a/BlockchainSdk/Common/PendingTransactionRecord.swift
+++ b/BlockchainSdk/Common/PendingTransactionRecord.swift
@@ -1,0 +1,73 @@
+//
+//  PendingTransactionRecord.swift
+//  BlockchainSdk
+//
+//  Created by Sergey Balashov on 04.10.2023.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+/// Use it in the `Wallet`model like a pending transaction which
+public struct PendingTransactionRecord {
+    public let hash: String
+    public let source: String
+    public let destination: String
+    public let amount: Amount
+    public let fee: Fee
+    public let date: Date
+    public let isIncoming: Bool
+    public let transactionParams: TransactionParams?
+    
+    public var isDummy: Bool {
+        hash == .unknown || source == .unknown || destination == .unknown
+    }
+    
+    public init(
+        hash: String,
+        source: String,
+        destination: String,
+        amount: Amount,
+        fee: Fee,
+        date: Date,
+        isIncoming: Bool,
+        transactionParams: TransactionParams? = nil
+    ) {
+        self.hash = hash
+        self.source = source
+        self.destination = destination
+        self.amount = amount
+        self.fee = fee
+        self.date = date
+        self.isIncoming = isIncoming
+        self.transactionParams = transactionParams
+    }
+}
+
+struct PendingTransactionRecordMapper {
+    func makeDummy(blockchain: Blockchain) -> PendingTransactionRecord {
+        PendingTransactionRecord(
+            hash: .unknown,
+            source: .unknown,
+            destination: .unknown,
+            amount: .zeroCoin(for: blockchain),
+            fee: Fee(.zeroCoin(for: blockchain)),
+            date: Date(),
+            isIncoming: false,
+            transactionParams: nil
+        )
+    }
+    
+    func mapToPendingTransactionRecord(_ pendingTransaction: PendingTransaction, blockchain: Blockchain) -> PendingTransactionRecord {
+        PendingTransactionRecord(
+            hash: pendingTransaction.hash,
+            source: pendingTransaction.source,
+            destination: pendingTransaction.destination,
+            amount: Amount(with: blockchain, value: pendingTransaction.value),
+            fee: Fee(Amount(with: blockchain, value: pendingTransaction.fee ?? 0)),
+            date: pendingTransaction.date,
+            isIncoming: pendingTransaction.isIncoming,
+            transactionParams: pendingTransaction.transactionParams
+        )
+    }
+}

--- a/BlockchainSdk/Common/PendingTransactionRecordMapper.swift
+++ b/BlockchainSdk/Common/PendingTransactionRecordMapper.swift
@@ -22,6 +22,24 @@ struct PendingTransactionRecordMapper {
         )
     }
     
+    func mapToPendingTransactionRecord(
+        transaction: Transaction,
+        hash: String,
+        date: Date = Date(),
+        isIncoming: Bool = false
+    ) -> PendingTransactionRecord {
+        PendingTransactionRecord(
+            hash: hash,
+            source: transaction.sourceAddress,
+            destination: transaction.destinationAddress,
+            amount: transaction.amount,
+            fee: transaction.fee,
+            date: date,
+            isIncoming: isIncoming,
+            transactionParams: transaction.params
+        )
+    }
+    
     func mapToPendingTransactionRecord(_ pendingTransaction: PendingTransaction, blockchain: Blockchain) -> PendingTransactionRecord {
         PendingTransactionRecord(
             hash: pendingTransaction.hash,

--- a/BlockchainSdk/Common/PendingTransactionRecordMapper.swift
+++ b/BlockchainSdk/Common/PendingTransactionRecordMapper.swift
@@ -1,0 +1,37 @@
+//
+//  PendingTransactionRecordMapper.swift
+//  BlockchainSdk
+//
+//  Created by Sergey Balashov on 05.10.2023.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+struct PendingTransactionRecordMapper {
+    func makeDummy(blockchain: Blockchain) -> PendingTransactionRecord {
+        PendingTransactionRecord(
+            hash: .unknown,
+            source: .unknown,
+            destination: .unknown,
+            amount: .zeroCoin(for: blockchain),
+            fee: Fee(.zeroCoin(for: blockchain)),
+            date: Date(),
+            isIncoming: false,
+            transactionParams: nil
+        )
+    }
+    
+    func mapToPendingTransactionRecord(_ pendingTransaction: PendingTransaction, blockchain: Blockchain) -> PendingTransactionRecord {
+        PendingTransactionRecord(
+            hash: pendingTransaction.hash,
+            source: pendingTransaction.source,
+            destination: pendingTransaction.destination,
+            amount: Amount(with: blockchain, value: pendingTransaction.value),
+            fee: Fee(Amount(with: blockchain, value: pendingTransaction.fee ?? 0)),
+            date: pendingTransaction.date,
+            isIncoming: pendingTransaction.isIncoming,
+            transactionParams: pendingTransaction.transactionParams
+        )
+    }
+}

--- a/BlockchainSdk/Common/Transaction.swift
+++ b/BlockchainSdk/Common/Transaction.swift
@@ -21,14 +21,11 @@ public struct Transaction {
     
     public init(
         amount: Amount,
-                fee: Fee,
-                sourceAddress: String,
-                destinationAddress: String,
-                changeAddress: String,
-                contractAddress: String? = nil
-//                date: Date? = nil,
-//                status: TransactionStatus = .unconfirmed,
-//                hash: String? = nil
+        fee: Fee,
+        sourceAddress: String,
+        destinationAddress: String,
+        changeAddress: String,
+        contractAddress: String? = nil
     ) {
         self.amount = amount
         self.fee = fee
@@ -36,9 +33,6 @@ public struct Transaction {
         self.destinationAddress = destinationAddress
         self.changeAddress = changeAddress
         self.contractAddress = contractAddress
-//        self.date = date
-//        self.status = status
-//        self.hash = hash
     }
     
     func asPending(hash: String, date: Date = Date(), isIncoming: Bool = false) -> PendingTransactionRecord {
@@ -57,23 +51,12 @@ public struct Transaction {
 
 extension Transaction: Equatable {
     public static func == (lhs: Transaction, rhs: Transaction) -> Bool {
-//        if lhs.hash != nil && rhs.hash != nil {
-//            return lhs.hash == rhs.hash
-//        }
-        
-        return lhs.amount == rhs.amount &&
-            lhs.fee == rhs.fee &&
-            lhs.sourceAddress == rhs.sourceAddress &&
-            lhs.destinationAddress == rhs.destinationAddress &&
-            lhs.changeAddress == rhs.changeAddress
-//            lhs.date == rhs.date &&
-//            lhs.status == rhs.status
+        lhs.amount == rhs.amount &&
+        lhs.fee == rhs.fee &&
+        lhs.sourceAddress == rhs.sourceAddress &&
+        lhs.destinationAddress == rhs.destinationAddress &&
+        lhs.changeAddress == rhs.changeAddress
     }
-}
-
-public enum TransactionStatus: Equatable {
-    case unconfirmed
-    case confirmed
 }
 
 public struct TransactionErrors: Error, LocalizedError, Equatable {

--- a/BlockchainSdk/Common/Transaction.swift
+++ b/BlockchainSdk/Common/Transaction.swift
@@ -34,19 +34,6 @@ public struct Transaction {
         self.changeAddress = changeAddress
         self.contractAddress = contractAddress
     }
-    
-    func asPending(hash: String, date: Date = Date(), isIncoming: Bool = false) -> PendingTransactionRecord {
-        PendingTransactionRecord(
-            hash: hash,
-            source: sourceAddress,
-            destination: destinationAddress,
-            amount: amount,
-            fee: fee,
-            date: date,
-            isIncoming: isIncoming,
-            transactionParams: params
-        )
-    }
 }
 
 extension Transaction: Equatable {

--- a/BlockchainSdk/Common/Transaction.swift
+++ b/BlockchainSdk/Common/Transaction.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import BitcoinCore
 
 public protocol TransactionParams {}
 
@@ -18,56 +17,57 @@ public struct Transaction {
     public let destinationAddress: String
     public let changeAddress: String
     public let contractAddress: String?
-    public internal(set) var date: Date? = nil
-    public internal(set) var status: TransactionStatus = .unconfirmed
-    public internal(set) var hash: String? = nil
     public var params: TransactionParams? = nil
     
-    public init(amount: Amount,
+    public init(
+        amount: Amount,
                 fee: Fee,
                 sourceAddress: String,
                 destinationAddress: String,
                 changeAddress: String,
-                contractAddress: String? = nil,
-                date: Date? = nil,
-                status: TransactionStatus = .unconfirmed,
-                hash: String? = nil) {
+                contractAddress: String? = nil
+//                date: Date? = nil,
+//                status: TransactionStatus = .unconfirmed,
+//                hash: String? = nil
+    ) {
         self.amount = amount
         self.fee = fee
         self.sourceAddress = sourceAddress
         self.destinationAddress = destinationAddress
         self.changeAddress = changeAddress
         self.contractAddress = contractAddress
-        self.date = date
-        self.status = status
-        self.hash = hash
+//        self.date = date
+//        self.status = status
+//        self.hash = hash
     }
     
-    public static func dummyTx(blockchain: Blockchain,
-                               type: Amount.AmountType,
-                               sourceAddress: String = .unknown,
-                               destinationAddress: String) -> Transaction {
-        Transaction(amount: Amount(with: blockchain, type: type, value: 0),
-                    fee: Fee(Amount(with: blockchain, type: type, value: 0)),
-                    sourceAddress: sourceAddress,
-                    destinationAddress: destinationAddress,
-                    changeAddress: sourceAddress)
+    func asPending(hash: String, date: Date = Date(), isIncoming: Bool = false) -> PendingTransactionRecord {
+        PendingTransactionRecord(
+            hash: hash,
+            source: sourceAddress,
+            destination: destinationAddress,
+            amount: amount,
+            fee: fee,
+            date: date,
+            isIncoming: isIncoming,
+            transactionParams: params
+        )
     }
 }
 
 extension Transaction: Equatable {
     public static func == (lhs: Transaction, rhs: Transaction) -> Bool {
-        if lhs.hash != nil && rhs.hash != nil {
-            return lhs.hash == rhs.hash
-        }
+//        if lhs.hash != nil && rhs.hash != nil {
+//            return lhs.hash == rhs.hash
+//        }
         
         return lhs.amount == rhs.amount &&
             lhs.fee == rhs.fee &&
             lhs.sourceAddress == rhs.sourceAddress &&
             lhs.destinationAddress == rhs.destinationAddress &&
-            lhs.changeAddress == rhs.changeAddress &&
-            lhs.date == rhs.date &&
-            lhs.status == rhs.status
+            lhs.changeAddress == rhs.changeAddress
+//            lhs.date == rhs.date &&
+//            lhs.status == rhs.status
     }
 }
 

--- a/BlockchainSdk/Common/TransactionCreator.swift
+++ b/BlockchainSdk/Common/TransactionCreator.swift
@@ -16,9 +16,7 @@ public protocol TransactionCreator {
         sourceAddress: String?,
         destinationAddress: String,
         changeAddress: String?,
-        contractAddress: String?,
-        date: Date,
-        status: TransactionStatus
+        contractAddress: String?
     ) throws -> Transaction
     
     func validate(fee: Fee) throws
@@ -33,9 +31,7 @@ public extension TransactionCreator {
         sourceAddress: String? = nil,
         destinationAddress: String,
         changeAddress: String? = nil,
-        contractAddress: String? = nil,
-        date: Date = Date(),
-        status: TransactionStatus = .unconfirmed
+        contractAddress: String? = nil
     ) throws -> Transaction {
         try self.createTransaction(
             amount: amount,
@@ -43,9 +39,7 @@ public extension TransactionCreator {
             sourceAddress: sourceAddress,
             destinationAddress: destinationAddress,
             changeAddress: changeAddress,
-            contractAddress: contractAddress,
-            date: date,
-            status: status
+            contractAddress: contractAddress
         )
     }
 }

--- a/BlockchainSdk/Common/Wallet.swift
+++ b/BlockchainSdk/Common/Wallet.swift
@@ -121,21 +121,12 @@ public struct Wallet {
 // MARK: - Pending Transaction
 
 extension Wallet {
-    mutating func addPendingTransaction(_ tx: PendingTransaction) {
-        // If already added
-        if pendingTransactions.contains(where: { $0.hash == tx.hash }) {
+    mutating func addPendingTransaction(_ transaction: PendingTransactionRecord) {
+        if pendingTransactions.contains(where: { $0.hash == transaction.hash }) {
             return
         }
-        
-        // Only with the correct address
-        if addresses.contains(where: { $0.value == tx.source }),
-            addresses.contains(where: { $0.value == tx.destination }) {
-            return
-        }
-        
-        let mapper = PendingTransactionRecordMapper()
-        let record = mapper.mapToPendingTransactionRecord(tx, blockchain: blockchain)
-        addPendingTransaction(record)
+
+        pendingTransactions.append(transaction)
     }
     
     mutating func addDummyPendingTransaction() {
@@ -143,14 +134,6 @@ extension Wallet {
         let record = mapper.makeDummy(blockchain: blockchain)
         
         addPendingTransaction(record)
-    }
-    
-    mutating func addPendingTransaction(_ transaction: PendingTransactionRecord) {
-        if pendingTransactions.contains(where: { $0.hash == transaction.hash }) {
-            return
-        }
-
-        pendingTransactions.append(transaction)
     }
     
     mutating func removePendingTransaction(hashes: [String]) {

--- a/BlockchainSdk/Common/Wallet.swift
+++ b/BlockchainSdk/Common/Wallet.swift
@@ -136,10 +136,14 @@ extension Wallet {
         addPendingTransaction(record)
     }
     
-    mutating func removePendingTransaction(hashes: [String]) {
+    mutating func removePendingTransaction(hashes: [String], isSensitiveCase: Bool = false) {
         pendingTransactions.removeAll { transaction in
             !hashes.contains { hash in
-                hash.caseInsensitiveCompare(transaction.hash) == .orderedSame
+                if isSensitiveCase {
+                    return hash == transaction.hash
+                }
+                
+                return hash.caseInsensitiveCompare(transaction.hash) == .orderedSame
             }
         }
     }

--- a/BlockchainSdk/Common/Wallet.swift
+++ b/BlockchainSdk/Common/Wallet.swift
@@ -159,7 +159,7 @@ extension Wallet {
         }
     }
     
-    /// Clear a pending transaction which was sent early then timeInterval in seconds
+    /// Delete a pending transaction that was sent earlier than the time interval in seconds
     mutating func clearPendingTransaction(timeInterval: TimeInterval) {
         let currentDate = Date()
 

--- a/BlockchainSdk/Common/Wallet.swift
+++ b/BlockchainSdk/Common/Wallet.swift
@@ -137,16 +137,18 @@ extension Wallet {
     }
     
     mutating func removePendingTransaction(hashes: [String]) {
-        pendingTransactions = pendingTransactions.filter { transaction in
-            !hashes.contains(transaction.hash)
+        pendingTransactions.removeAll { transaction in
+            !hashes.contains { hash in
+                hash.caseInsensitiveCompare(transaction.hash) == .orderedSame
+            }
         }
     }
     
     /// Delete a pending transaction that was sent earlier than the time interval in seconds
-    mutating func clearPendingTransaction(timeInterval: TimeInterval) {
+    mutating func clearPendingTransaction(older timeInterval: TimeInterval) {
         let currentDate = Date()
 
-        pendingTransactions = pendingTransactions.filter { transaction in
+        pendingTransactions.removeAll { transaction in
             let interval = currentDate.timeIntervalSince(transaction.date)
             return interval < timeInterval
         }

--- a/BlockchainSdk/Common/Wallet.swift
+++ b/BlockchainSdk/Common/Wallet.swift
@@ -144,13 +144,9 @@ extension Wallet {
         }
     }
     
-    /// Delete a pending transaction that was sent earlier than the time interval in seconds
-    mutating func clearPendingTransaction(older timeInterval: TimeInterval) {
-        let currentDate = Date()
-
+    mutating func removePendingTransaction(older date: Date) {
         pendingTransactions.removeAll { transaction in
-            let interval = currentDate.timeIntervalSince(transaction.date)
-            return interval < timeInterval
+            transaction.date < date
         }
     }
     

--- a/BlockchainSdk/Common/Wallet.swift
+++ b/BlockchainSdk/Common/Wallet.swift
@@ -136,15 +136,9 @@ extension Wallet {
         addPendingTransaction(record)
     }
     
-    mutating func removePendingTransaction(hashes: [String], isSensitiveCase: Bool = false) {
+    mutating func removePendingTransaction(where compare: (String) -> Bool) {
         pendingTransactions.removeAll { transaction in
-            !hashes.contains { hash in
-                if isSensitiveCase {
-                    return hash == transaction.hash
-                }
-                
-                return hash.caseInsensitiveCompare(transaction.hash) == .orderedSame
-            }
+            compare(transaction.hash)
         }
     }
     

--- a/BlockchainSdk/WalletManagers/Binance/BinanceWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Binance/BinanceWalletManager.swift
@@ -44,7 +44,9 @@ class BinanceWalletManager: BaseManager, WalletManager {
         
         txBuilder.binanceWallet.sequence = response.sequence
         txBuilder.binanceWallet.accountNumber = response.accountNumber
-        wallet.clearPendingTransaction(older: 10)
+        // We believe that a transaction will be confirmed within 10 seconds
+        let date = Date(timeIntervalSinceNow: -10)
+        wallet.removePendingTransaction(older: date)
     }
 }
 

--- a/BlockchainSdk/WalletManagers/Binance/BinanceWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Binance/BinanceWalletManager.swift
@@ -44,13 +44,7 @@ class BinanceWalletManager: BaseManager, WalletManager {
         
         txBuilder.binanceWallet.sequence = response.sequence
         txBuilder.binanceWallet.accountNumber = response.accountNumber
-        
-        let currentDate = Date()
-        for index in wallet.transactions.indices {
-            if DateInterval(start: wallet.transactions[index].date!, end: currentDate).duration > 10 {
-                wallet.transactions[index].status = .confirmed
-            }
-        }
+        wallet.clearPendingTransaction(timeInterval: 10)
     }
 }
 
@@ -73,11 +67,12 @@ extension BinanceWalletManager: TransactionSender {
                 return tx
             }
             .flatMap {[weak self] tx -> AnyPublisher<TransactionSendResult, Error> in
-                self?.networkService.send(transaction: tx).tryMap {[weak self] response in
+                self?.networkService.send(transaction: tx).tryMap { [weak self] response in
                     guard let self = self else { throw WalletError.empty }
-                    self.wallet.add(transaction: transaction)
+                    let hash = response.tx.txHash
+                    self.wallet.addPendingTransaction(transaction.asPending(hash: hash))
                     self.latestTxDate = Date()
-                    return TransactionSendResult(hash: response.tx.txHash)
+                    return TransactionSendResult(hash: hash)
 
                 }.eraseToAnyPublisher() ?? .emptyFail
             }

--- a/BlockchainSdk/WalletManagers/Binance/BinanceWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Binance/BinanceWalletManager.swift
@@ -44,7 +44,7 @@ class BinanceWalletManager: BaseManager, WalletManager {
         
         txBuilder.binanceWallet.sequence = response.sequence
         txBuilder.binanceWallet.accountNumber = response.accountNumber
-        wallet.clearPendingTransaction(timeInterval: 10)
+        wallet.clearPendingTransaction(older: 10)
     }
 }
 
@@ -70,7 +70,9 @@ extension BinanceWalletManager: TransactionSender {
                 self?.networkService.send(transaction: tx).tryMap { [weak self] response in
                     guard let self = self else { throw WalletError.empty }
                     let hash = response.tx.txHash
-                    self.wallet.addPendingTransaction(transaction.asPending(hash: hash))
+                    let mapper = PendingTransactionRecordMapper()
+                    let record = mapper.mapToPendingTransactionRecord(transaction: transaction, hash: hash)
+                    self.wallet.addPendingTransaction(record)
                     self.latestTxDate = Date()
                     return TransactionSendResult(hash: hash)
 

--- a/BlockchainSdk/WalletManagers/Bitcoin/BitcoinWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Bitcoin/BitcoinWalletManager.swift
@@ -100,11 +100,12 @@ class BitcoinWalletManager: BaseManager, WalletManager, DustRestrictable {
                     txHashPublisher = self.networkService.send(transaction: tx)
                 }
                 
-                return txHashPublisher.tryMap {[weak self] sendResponse in
+                return txHashPublisher.tryMap {[weak self] hash in
                     guard let self = self else { throw WalletError.empty }
                     
-                    let hash = sendResponse
-                    self.wallet.addPendingTransaction(transaction.asPending(hash: hash))
+                    let mapper = PendingTransactionRecordMapper()
+                    let record = mapper.mapToPendingTransactionRecord(transaction: transaction, hash: hash)
+                    self.wallet.addPendingTransaction(record)
                     return TransactionSendResult(hash: hash)
                 }
                 .mapError { SendTxError(error: $0, tx: tx) }

--- a/BlockchainSdk/WalletManagers/Bitcoin/BitcoinWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Bitcoin/BitcoinWalletManager.swift
@@ -55,7 +55,11 @@ class BitcoinWalletManager: BaseManager, WalletManager, DustRestrictable {
         if hasUnconfirmed {
             response
                 .flatMap { $0.pendingTxRefs }
-                .forEach { wallet.addPendingTransaction($0) }
+                .forEach {
+                    let mapper = PendingTransactionRecordMapper()
+                    let transaction = mapper.mapToPendingTransactionRecord($0, blockchain: wallet.blockchain)
+                    wallet.addPendingTransaction(transaction)
+                }
         }
     }
     

--- a/BlockchainSdk/WalletManagers/Cardano/CardanoWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Cardano/CardanoWalletManager.swift
@@ -37,8 +37,12 @@ class CardanoWalletManager: BaseManager, WalletManager {
             wallet.add(tokenValue: value, for: key)
         }
        
-        wallet.removePendingTransaction(hashes: response.recentTransactionsHashes)
-        
+        wallet.removePendingTransaction { hash in
+            response.recentTransactionsHashes.contains {
+                $0.lowercased() == hash.lowercased()
+            }
+        }
+
         // If we have pending transaction but we haven't unspentOutputs then clear it
         if response.recentTransactionsHashes.isEmpty, response.unspentOutputs.isEmpty {
             wallet.clearPendingTransaction()

--- a/BlockchainSdk/WalletManagers/Cardano/CardanoWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Cardano/CardanoWalletManager.swift
@@ -39,7 +39,7 @@ class CardanoWalletManager: BaseManager, WalletManager {
        
         wallet.removePendingTransaction { hash in
             response.recentTransactionsHashes.contains {
-                $0.lowercased() == hash.lowercased()
+                $0.caseInsensitiveCompare(hash) == .orderedSame
             }
         }
 

--- a/BlockchainSdk/WalletManagers/Cardano/CardanoWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Cardano/CardanoWalletManager.swift
@@ -40,9 +40,7 @@ class CardanoWalletManager: BaseManager, WalletManager {
         wallet.removePendingTransaction(hashes: response.recentTransactionsHashes)
         
         // If we have pending transaction but we haven't unspentOutputs then clear it
-        if response.recentTransactionsHashes.isEmpty,
-           !wallet.pendingTransactions.isEmpty,
-           response.unspentOutputs.isEmpty {
+        if response.recentTransactionsHashes.isEmpty, response.unspentOutputs.isEmpty {
             wallet.clearPendingTransaction()
         }
     }
@@ -91,7 +89,9 @@ extension CardanoWalletManager: TransactionSender {
                         throw WalletError.empty
                     }
 
-                    self.wallet.addPendingTransaction(transaction.asPending(hash: hash))
+                    let mapper = PendingTransactionRecordMapper()
+                    let record = mapper.mapToPendingTransactionRecord(transaction: transaction, hash: hash)
+                    self.wallet.addPendingTransaction(record)
                     return TransactionSendResult(hash: hash)
                 }
                 .eraseToAnyPublisher()

--- a/BlockchainSdk/WalletManagers/Cardano/CardanoWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Cardano/CardanoWalletManager.swift
@@ -40,7 +40,9 @@ class CardanoWalletManager: BaseManager, WalletManager {
         wallet.removePendingTransaction(hashes: response.recentTransactionsHashes)
         
         // If we have pending transaction but we haven't unspentOutputs then clear it
-        if !wallet.pendingTransactions.isEmpty, response.unspentOutputs.isEmpty {
+        if response.recentTransactionsHashes.isEmpty,
+           !wallet.pendingTransactions.isEmpty,
+           response.unspentOutputs.isEmpty {
             wallet.clearPendingTransaction()
         }
     }

--- a/BlockchainSdk/WalletManagers/Chia/ChiaWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Chia/ChiaWalletManager.swift
@@ -71,7 +71,7 @@ final class ChiaWalletManager: BaseManager, WalletManager {
                 return self.networkService.send(spendBundle: spendBundle)
             }
             .map { [weak self] hash in
-                self?.wallet.add(transaction: transaction)
+                self?.wallet.addPendingTransaction(transaction.asPending(hash: hash))
                 return TransactionSendResult(hash: hash)
             }
             .eraseToAnyPublisher()
@@ -107,7 +107,7 @@ private extension ChiaWalletManager {
         let coinBalance = decimalBalance / wallet.blockchain.decimalValue
         
         if coinBalance != wallet.amounts[.coin]?.value {
-            wallet.transactions = []
+            wallet.clearPendingTransaction()
         }
         
         wallet.add(coinValue: coinBalance)

--- a/BlockchainSdk/WalletManagers/Chia/ChiaWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Chia/ChiaWalletManager.swift
@@ -71,7 +71,9 @@ final class ChiaWalletManager: BaseManager, WalletManager {
                 return self.networkService.send(spendBundle: spendBundle)
             }
             .map { [weak self] hash in
-                self?.wallet.addPendingTransaction(transaction.asPending(hash: hash))
+                let mapper = PendingTransactionRecordMapper()
+                let record = mapper.mapToPendingTransactionRecord(transaction: transaction, hash: hash)
+                self?.wallet.addPendingTransaction(record)
                 return TransactionSendResult(hash: hash)
             }
             .eraseToAnyPublisher()

--- a/BlockchainSdk/WalletManagers/Cosmos/CosmosWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Cosmos/CosmosWalletManager.swift
@@ -91,7 +91,9 @@ class CosmosWalletManager: BaseManager, WalletManager {
                 return self.networkService.send(transaction: transaction)
             }
             .handleEvents(receiveOutput: { [weak self] hash in
-                self?.wallet.addPendingTransaction(transaction.asPending(hash: hash))
+                let mapper = PendingTransactionRecordMapper()
+                let record = mapper.mapToPendingTransactionRecord(transaction: transaction, hash: hash)
+                self?.wallet.addPendingTransaction(record)
             })
             .map {
                 TransactionSendResult(hash: $0)

--- a/BlockchainSdk/WalletManagers/Cosmos/CosmosWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Cosmos/CosmosWalletManager.swift
@@ -179,7 +179,9 @@ class CosmosWalletManager: BaseManager, WalletManager {
             wallet.add(tokenValue: balance, for: token)
         }
         
-        wallet.removePendingTransaction(hashes: accountInfo.confirmedTransactionHashes)
+        wallet.removePendingTransaction { hash in
+            accountInfo.confirmedTransactionHashes.contains(hash)
+        }
     }
     
     private func tax(for amount: Amount) -> UInt64? {

--- a/BlockchainSdk/WalletManagers/Cosmos/CosmosWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Cosmos/CosmosWalletManager.swift
@@ -27,9 +27,7 @@ class CosmosWalletManager: BaseManager, WalletManager {
     }
     
     override func update(completion: @escaping (Result<Void, Error>) -> Void) {
-        let transactionHashes = wallet.transactions
-            .filter { $0.status == .unconfirmed }
-            .compactMap { $0.hash }
+        let transactionHashes = wallet.pendingTransactions.map { $0.hash }
         
         cancellable = networkService
             .accountInfo(for: wallet.address, tokens: cardTokens, transactionHashes: transactionHashes)
@@ -92,10 +90,8 @@ class CosmosWalletManager: BaseManager, WalletManager {
                 
                 return self.networkService.send(transaction: transaction)
             }
-            .handleEvents(receiveOutput: { [weak self] in
-                var submittedTransaction = transaction
-                submittedTransaction.hash = $0
-                self?.wallet.add(transaction: submittedTransaction)
+            .handleEvents(receiveOutput: { [weak self] hash in
+                self?.wallet.addPendingTransaction(transaction.asPending(hash: hash))
             })
             .map {
                 TransactionSendResult(hash: $0)
@@ -181,11 +177,7 @@ class CosmosWalletManager: BaseManager, WalletManager {
             wallet.add(tokenValue: balance, for: token)
         }
         
-        for (index, transaction) in wallet.transactions.enumerated() {
-            if let hash = transaction.hash, accountInfo.confirmedTransactionHashes.contains(hash) {
-                wallet.transactions[index].status = .confirmed
-            }
-        }
+        wallet.removePendingTransaction(hashes: accountInfo.confirmedTransactionHashes)
     }
     
     private func tax(for amount: Amount) -> UInt64? {

--- a/BlockchainSdk/WalletManagers/Ducatus/DucatusWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Ducatus/DucatusWalletManager.swift
@@ -13,10 +13,12 @@ class DucatusWalletManager: BitcoinWalletManager {
         wallet.add(coinValue: singleResponse.balance)
         txBuilder.unspentOutputs = singleResponse.unspentOutputs
         loadedUnspents = singleResponse.unspentOutputs
-        if singleResponse.hasUnconfirmed, wallet.pendingTransactions.isEmpty {
-            wallet.addDummyPendingTransaction()
+        if singleResponse.hasUnconfirmed {
+            if wallet.pendingTransactions.isEmpty {
+                wallet.addDummyPendingTransaction()
+            }
         } else {
-            wallet.clearPendingTransaction(timeInterval: 30)
+            wallet.clearPendingTransaction(older: 30)
         }
     }
 }

--- a/BlockchainSdk/WalletManagers/Ducatus/DucatusWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Ducatus/DucatusWalletManager.swift
@@ -13,19 +13,10 @@ class DucatusWalletManager: BitcoinWalletManager {
         wallet.add(coinValue: singleResponse.balance)
         txBuilder.unspentOutputs = singleResponse.unspentOutputs
         loadedUnspents = singleResponse.unspentOutputs
-        if singleResponse.hasUnconfirmed {
-            if wallet.transactions.isEmpty {
-                wallet.addDummyPendingTransaction()
-            }
+        if singleResponse.hasUnconfirmed, wallet.pendingTransactions.isEmpty {
+            wallet.addDummyPendingTransaction()
         } else {
-            for index in wallet.transactions.indices {
-                if let txDate = wallet.transactions[index].date {
-                    let interval = Date().timeIntervalSince(txDate)
-                    if interval > 30 {
-                        wallet.transactions[index].status = .confirmed
-                    }
-                }
-            }
+            wallet.clearPendingTransaction(timeInterval: 30)
         }
     }
 }

--- a/BlockchainSdk/WalletManagers/Ducatus/DucatusWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Ducatus/DucatusWalletManager.swift
@@ -18,7 +18,9 @@ class DucatusWalletManager: BitcoinWalletManager {
                 wallet.addDummyPendingTransaction()
             }
         } else {
-            wallet.clearPendingTransaction(older: 30)
+            // We believe that a transaction will be confirmed within 30 seconds
+            let date = Date(timeIntervalSinceNow: -30)
+            wallet.removePendingTransaction(older: date)
         }
     }
 }

--- a/BlockchainSdk/WalletManagers/Ethereum/EthereumWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Ethereum/EthereumWalletManager.swift
@@ -130,8 +130,10 @@ private extension EthereumWalletManager {
         
         if txCount == pendingTxCount {
             wallet.clearPendingTransaction()
-        } else if response.pendingTxs.isEmpty, wallet.pendingTransactions.isEmpty {
-            wallet.addDummyPendingTransaction()
+        } else if response.pendingTxs.isEmpty {
+            if wallet.pendingTransactions.isEmpty {
+                wallet.addDummyPendingTransaction()
+            }
         } else {
             wallet.clearPendingTransaction()
             response.pendingTxs.forEach {
@@ -172,11 +174,12 @@ extension EthereumWalletManager: TransactionSender {
     func send(_ transaction: Transaction, signer: TransactionSigner) -> AnyPublisher<TransactionSendResult, Error> {
         sign(transaction, signer: signer)
             .flatMap {[weak self] tx -> AnyPublisher<TransactionSendResult, Error> in
-                self?.networkService.send(transaction: tx).tryMap {[weak self] sendResponse in
+                self?.networkService.send(transaction: tx).tryMap {[weak self] hash in
                     guard let self = self else { throw WalletError.empty }
                     
-                    let hash = sendResponse
-                    self.wallet.addPendingTransaction(transaction.asPending(hash: hash))
+                    let mapper = PendingTransactionRecordMapper()
+                    let record = mapper.mapToPendingTransactionRecord(transaction: transaction, hash: hash)
+                    self.wallet.addPendingTransaction(record)
                     return TransactionSendResult(hash: hash)
                 }
                 .mapError { SendTxError(error: $0, tx: tx) }

--- a/BlockchainSdk/WalletManagers/Ethereum/EthereumWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Ethereum/EthereumWalletManager.swift
@@ -135,7 +135,9 @@ private extension EthereumWalletManager {
         } else {
             wallet.clearPendingTransaction()
             response.pendingTxs.forEach {
-                wallet.addPendingTransaction($0)
+                let mapper = PendingTransactionRecordMapper()
+                let transaction = mapper.mapToPendingTransactionRecord($0, blockchain: wallet.blockchain)
+                wallet.addPendingTransaction(transaction)
             }
         }
     }

--- a/BlockchainSdk/WalletManagers/Kaspa/KaspaWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Kaspa/KaspaWalletManager.swift
@@ -17,9 +17,7 @@ class KaspaWalletManager: BaseManager, WalletManager {
     var allowsFeeSelection: Bool { false }
     
     override func update(completion: @escaping (Result<Void, Error>) -> Void) {
-        let unconfirmedTransactionHashes = wallet.transactions
-            .filter { $0.status == .unconfirmed }
-            .compactMap { $0.hash }
+        let unconfirmedTransactionHashes = wallet.pendingTransactions.map { $0.hash }
         
         cancellable = networkService.getInfo(address: wallet.address, unconfirmedTransactionHashes: unconfirmedTransactionHashes)
             .sink { result in
@@ -59,9 +57,7 @@ class KaspaWalletManager: BaseManager, WalletManager {
                 return self.networkService.send(transaction: KaspaTransactionRequest(transaction: tx))
             }
             .handleEvents(receiveOutput: { [weak self] in
-                var submittedTransaction = transaction
-                submittedTransaction.hash = $0.transactionId
-                self?.wallet.transactions.append(submittedTransaction)
+                self?.wallet.addPendingTransaction(transaction.asPending(hash: $0.transactionId))
             })
             .map {
                 TransactionSendResult(hash: $0.transactionId)
@@ -87,12 +83,7 @@ class KaspaWalletManager: BaseManager, WalletManager {
     private func updateWallet(_ info: KaspaAddressInfo) {
         self.wallet.add(amount: Amount(with: self.wallet.blockchain, value: info.balance))
         txBuilder.setUnspentOutputs(info.unspentOutputs)
-        
-        for (index, transaction) in wallet.transactions.enumerated() {
-            if let hash = transaction.hash, info.confirmedTransactionHashes.contains(hash) {
-                wallet.transactions[index].status = .confirmed
-            }
-        }
+        wallet.removePendingTransaction(hashes: info.confirmedTransactionHashes)
     }
 }
 

--- a/BlockchainSdk/WalletManagers/Kaspa/KaspaWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Kaspa/KaspaWalletManager.swift
@@ -18,7 +18,7 @@ class KaspaWalletManager: BaseManager, WalletManager {
     
     override func update(completion: @escaping (Result<Void, Error>) -> Void) {
         let unconfirmedTransactionHashes = wallet.pendingTransactions.map { $0.hash }
-        
+
         cancellable = networkService.getInfo(address: wallet.address, unconfirmedTransactionHashes: unconfirmedTransactionHashes)
             .sink { result in
                 switch result {
@@ -85,7 +85,9 @@ class KaspaWalletManager: BaseManager, WalletManager {
     private func updateWallet(_ info: KaspaAddressInfo) {
         self.wallet.add(amount: Amount(with: self.wallet.blockchain, value: info.balance))
         txBuilder.setUnspentOutputs(info.unspentOutputs)
-        wallet.removePendingTransaction(hashes: info.confirmedTransactionHashes)
+        wallet.removePendingTransaction { hash in
+            info.confirmedTransactionHashes.contains(hash)
+        }
     }
 }
 

--- a/BlockchainSdk/WalletManagers/Kaspa/KaspaWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Kaspa/KaspaWalletManager.swift
@@ -57,7 +57,9 @@ class KaspaWalletManager: BaseManager, WalletManager {
                 return self.networkService.send(transaction: KaspaTransactionRequest(transaction: tx))
             }
             .handleEvents(receiveOutput: { [weak self] in
-                self?.wallet.addPendingTransaction(transaction.asPending(hash: $0.transactionId))
+                let mapper = PendingTransactionRecordMapper()
+                let record = mapper.mapToPendingTransactionRecord(transaction: transaction, hash: $0.transactionId)
+                self?.wallet.addPendingTransaction(record)
             })
             .map {
                 TransactionSendResult(hash: $0.transactionId)

--- a/BlockchainSdk/WalletManagers/Polkadot/PolkadotWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Polkadot/PolkadotWalletManager.swift
@@ -49,7 +49,9 @@ class PolkadotWalletManager: BaseManager, WalletManager {
         }
         
         wallet.add(amount: .init(with: wallet.blockchain, value: value))
-        wallet.clearPendingTransaction(older: 10)
+        // We believe that a transaction will be confirmed within 10 seconds
+        let date = Date(timeIntervalSinceNow: -10)
+        wallet.removePendingTransaction(older: date)
     }
 }
 

--- a/BlockchainSdk/WalletManagers/Solana/SolanaWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Solana/SolanaWalletManager.swift
@@ -61,13 +61,15 @@ extension SolanaWalletManager: TransactionSender {
         }
         
         return sendPublisher
-            .tryMap { [weak self] transactionID in
+            .tryMap { [weak self] hash in
                 guard let self = self else {
                     throw WalletError.empty
                 }
 
-                self.wallet.addPendingTransaction(transaction.asPending(hash: transactionID))
-                return TransactionSendResult(hash: transactionID)
+                let mapper = PendingTransactionRecordMapper()
+                let record = mapper.mapToPendingTransactionRecord(transaction: transaction, hash: hash)
+                self.wallet.addPendingTransaction(record)
+                return TransactionSendResult(hash: hash)
             }
             .eraseToAnyPublisher()
     }

--- a/BlockchainSdk/WalletManagers/Solana/SolanaWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Solana/SolanaWalletManager.swift
@@ -42,7 +42,7 @@ class SolanaWalletManager: BaseManager, WalletManager {
             self.wallet.add(tokenValue: balance, for: cardToken)
         }
         
-        wallet.removePendingTransaction(hashes: info.confirmedTransactionIDs)
+        wallet.removePendingTransaction(hashes: info.confirmedTransactionIDs, isSensitiveCase: true)
     }
 }
 

--- a/BlockchainSdk/WalletManagers/Solana/SolanaWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Solana/SolanaWalletManager.swift
@@ -42,7 +42,9 @@ class SolanaWalletManager: BaseManager, WalletManager {
             self.wallet.add(tokenValue: balance, for: cardToken)
         }
         
-        wallet.removePendingTransaction(hashes: info.confirmedTransactionIDs, isSensitiveCase: true)
+        wallet.removePendingTransaction { hash in
+            info.confirmedTransactionIDs.contains(hash)
+        }
     }
 }
 

--- a/BlockchainSdk/WalletManagers/Stellar/StellarWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Stellar/StellarWalletManager.swift
@@ -88,7 +88,9 @@ class StellarWalletManager: BaseManager, WalletManager {
             }
         }
 
-        wallet.clearPendingTransaction(older: 10)
+        // We believe that a transaction will be confirmed within 10 seconds
+        let date = Date(timeIntervalSinceNow: -10)
+        wallet.removePendingTransaction(older: date)
     }
 }
 

--- a/BlockchainSdk/WalletManagers/TON/TONWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/TON/TONWalletManager.swift
@@ -75,7 +75,9 @@ final class TONWalletManager: BaseManager, WalletManager {
                 return self.networkService.send(message: message)
             }
             .map { [weak self] hash in
-                self?.wallet.addPendingTransaction(transaction.asPending(hash: hash))
+                let mapper = PendingTransactionRecordMapper()
+                let record = mapper.mapToPendingTransactionRecord(transaction: transaction, hash: hash)
+                self?.wallet.addPendingTransaction(record)
                 return TransactionSendResult(hash: hash)
             }
             .eraseToAnyPublisher()

--- a/BlockchainSdk/WalletManagers/TON/TONWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/TON/TONWalletManager.swift
@@ -75,7 +75,7 @@ final class TONWalletManager: BaseManager, WalletManager {
                 return self.networkService.send(message: message)
             }
             .map { [weak self] hash in
-                self?.wallet.add(transaction: transaction)
+                self?.wallet.addPendingTransaction(transaction.asPending(hash: hash))
                 return TransactionSendResult(hash: hash)
             }
             .eraseToAnyPublisher()
@@ -136,9 +136,7 @@ private extension TONWalletManager {
     
     private func update(with info: TONWalletInfo, completion: @escaping (Result<Void, Error>) -> Void) {
         if info.sequenceNumber != txBuilder.sequenceNumber {
-            for index in wallet.transactions.indices {
-                wallet.transactions[index].status = .confirmed
-            }
+            wallet.clearPendingTransaction()
         }
         
         wallet.add(coinValue: info.balance)

--- a/BlockchainSdk/WalletManagers/Tezos/TezosWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Tezos/TezosWalletManager.swift
@@ -35,7 +35,7 @@ class TezosWalletManager: BaseManager, WalletManager {
         txBuilder.counter = response.counter
         
         if response.balance != wallet.amounts[.coin]?.value {
-            wallet.transactions = []
+            wallet.clearPendingTransaction()
         }
         
         wallet.add(coinValue: response.balance)
@@ -93,8 +93,10 @@ extension TezosWalletManager: TransactionSender {
                     .tryMap{[weak self] response in
                         guard let self = self else { throw WalletError.empty }
                         
-                        self.wallet.add(transaction: transaction)
-                        return TransactionSendResult(hash: txToSend)
+                        let hash = txToSend
+
+                        self.wallet.addPendingTransaction(transaction.asPending(hash: hash))
+                        return TransactionSendResult(hash: hash)
                     }
                     .mapError { SendTxError(error: $0, tx: txToSend) }
                     .eraseToAnyPublisher()

--- a/BlockchainSdk/WalletManagers/Tron/TronWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Tron/TronWalletManager.swift
@@ -217,7 +217,7 @@ class TronWalletManager: BaseManager, WalletManager {
             wallet.add(tokenValue: balance, for: token)
         }
         
-        wallet.removePendingTransaction(hashes: accountInfo.confirmedTransactionIDs)
+        wallet.removePendingTransaction(hashes: accountInfo.confirmedTransactionIDs, isSensitiveCase: true)
     }
     
     private func unmarshal(_ signatureData: Data, hash: Data, publicKey: Wallet.PublicKey) -> Data {

--- a/BlockchainSdk/WalletManagers/Tron/TronWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Tron/TronWalletManager.swift
@@ -217,7 +217,9 @@ class TronWalletManager: BaseManager, WalletManager {
             wallet.add(tokenValue: balance, for: token)
         }
         
-        wallet.removePendingTransaction(hashes: accountInfo.confirmedTransactionIDs, isSensitiveCase: true)
+        wallet.removePendingTransaction { hash in
+            accountInfo.confirmedTransactionIDs.contains(hash)
+        }
     }
     
     private func unmarshal(_ signatureData: Data, hash: Data, publicKey: Wallet.PublicKey) -> Data {

--- a/BlockchainSdk/WalletManagers/Tron/TronWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Tron/TronWalletManager.swift
@@ -56,7 +56,9 @@ class TronWalletManager: BaseManager, WalletManager {
                 }
                 
                 let hash = broadcastResponse.txid
-                self?.wallet.addPendingTransaction(transaction.asPending(hash: hash))
+                let mapper = PendingTransactionRecordMapper()
+                let record = mapper.mapToPendingTransactionRecord(transaction: transaction, hash: hash)
+                self?.wallet.addPendingTransaction(record)
                 return TransactionSendResult(hash: hash)
             }
             .eraseToAnyPublisher()

--- a/BlockchainSdkTests/Solana/SolanaEd25519Slip0010Tests.swift
+++ b/BlockchainSdkTests/Solana/SolanaEd25519Slip0010Tests.swift
@@ -80,11 +80,15 @@ final class SolanaEd25519Slip0010Tests: XCTestCase {
     }
     
     func testCoinTransactionSize() {
-        let transaction = Transaction.dummyTx(blockchain: blockchain,
-                                              type: .coin,
-                                              sourceAddress: manager.wallet.address,
-                                              destinationAddress: "BmAzxn8WLYU3gEw79ATUdSUkMT53MeS5LjapBQB8gTPJ")
-        
+        let transaction = Transaction(
+            amount: .zeroCoin(for: blockchain),
+            fee: Fee(.zeroCoin(for: blockchain)),
+            sourceAddress: manager.wallet.address,
+            destinationAddress: "BmAzxn8WLYU3gEw79ATUdSUkMT53MeS5LjapBQB8gTPJ",
+            changeAddress: manager.wallet.address,
+            contractAddress: nil
+        )
+
         let expected = expectation(description: "Waiting for response")
         
         processResult(manager.send(transaction, signer: coinSigner), expectationToFill: expected)
@@ -92,13 +96,19 @@ final class SolanaEd25519Slip0010Tests: XCTestCase {
     }
     
     func testTokenTransactionSize() {
-        let transaction = Transaction.dummyTx(blockchain: blockchain,
-                                              type: .token(value: .init(name: "Solanax",
-                                                                        symbol: "SOLD",
-                                                                        contractAddress: "5v6tZ1SiAi7G8Qg4rBF1ZdAn4cn6aeQtefewMr1NLy61",
-                                                                        decimalCount: 9)),
-                                              sourceAddress: manager.wallet.address,
-                                              destinationAddress: "BmAzxn8WLYU3gEw79ATUdSUkMT53MeS5LjapBQB8gTPJ")
+        let type: Amount.AmountType = .token(
+            value: .init(name: "Solanax",
+                         symbol: "SOLD",
+                         contractAddress: "5v6tZ1SiAi7G8Qg4rBF1ZdAn4cn6aeQtefewMr1NLy61",
+                         decimalCount: 9)
+        )
+        let transaction = Transaction(
+            amount: Amount(with: blockchain, type: type, value: 0),
+            fee: Fee(Amount(with: blockchain, type: type, value: 0)),
+            sourceAddress: manager.wallet.address,
+            destinationAddress: "BmAzxn8WLYU3gEw79ATUdSUkMT53MeS5LjapBQB8gTPJ",
+            changeAddress: manager.wallet.address
+        )
         let expected = expectation(description: "Waiting for response")
         
         processResult(manager.send(transaction, signer: tokenSigner), expectationToFill: expected)

--- a/BlockchainSdkTests/Solana/SolanaEd25519Tests.swift
+++ b/BlockchainSdkTests/Solana/SolanaEd25519Tests.swift
@@ -80,10 +80,14 @@ final class SolanaEd25519Tests: XCTestCase {
     }
     
     func testCoinTransactionSize() {
-        let transaction = Transaction.dummyTx(blockchain: blockchain,
-                                              type: .coin,
-                                              sourceAddress: manager.wallet.address,
-                                              destinationAddress: "BmAzxn8WLYU3gEw79ATUdSUkMT53MeS5LjapBQB8gTPJ")
+        let transaction = Transaction(
+            amount: .zeroCoin(for: blockchain),
+            fee: Fee(.zeroCoin(for: blockchain)),
+            sourceAddress: manager.wallet.address,
+            destinationAddress: "BmAzxn8WLYU3gEw79ATUdSUkMT53MeS5LjapBQB8gTPJ",
+            changeAddress: manager.wallet.address,
+            contractAddress: nil
+        )
         
         let expected = expectation(description: "Waiting for response")
         
@@ -92,13 +96,19 @@ final class SolanaEd25519Tests: XCTestCase {
     }
     
     func testTokenTransactionSize() {
-        let transaction = Transaction.dummyTx(blockchain: blockchain,
-                                              type: .token(value: .init(name: "Solanax",
-                                                                        symbol: "SOLD",
-                                                                        contractAddress: "5v6tZ1SiAi7G8Qg4rBF1ZdAn4cn6aeQtefewMr1NLy61",
-                                                                        decimalCount: 9)),
-                                              sourceAddress: manager.wallet.address,
-                                              destinationAddress: "BmAzxn8WLYU3gEw79ATUdSUkMT53MeS5LjapBQB8gTPJ")
+        let type: Amount.AmountType = .token(
+            value: .init(name: "Solanax",
+                         symbol: "SOLD",
+                         contractAddress: "5v6tZ1SiAi7G8Qg4rBF1ZdAn4cn6aeQtefewMr1NLy61",
+                         decimalCount: 9)
+        )
+        let transaction = Transaction(
+            amount: Amount(with: blockchain, type: type, value: 0),
+            fee: Fee(Amount(with: blockchain, type: type, value: 0)),
+            sourceAddress: manager.wallet.address,
+            destinationAddress: "BmAzxn8WLYU3gEw79ATUdSUkMT53MeS5LjapBQB8gTPJ",
+            changeAddress: manager.wallet.address
+        )
         let expected = expectation(description: "Waiting for response")
         
         processResult(manager.send(transaction, signer: tokenSigner), expectationToFill: expected)


### PR DESCRIPTION
Решил разделить нашу "болванку" которую мы собираем для отправки и модель уже отправленной транзакции

главное отличие в том, что у уже отправленной есть `hash`, он не обходим для открытия транзакции в экспореле. 
и с такую транзакцию уже можно будет дополнять в дальнейшем. 

Модель `Transaction` чуть похудела и в дальнейшем она должна использоваться только как DTO для отправки