### PR TITLE
IOS-4928 Added proper solana address validation

### DIFF
--- a/BlockchainSdk/WalletManagers/Solana/SolanaAddressService.swift
+++ b/BlockchainSdk/WalletManagers/Solana/SolanaAddressService.swift
@@ -28,7 +28,9 @@ extension SolanaAddressService: AddressProvider {
 @available(iOS 13.0, *)
 extension SolanaAddressService: AddressValidator {
     public func validate(_ address: String) -> Bool {
-        let publicKey = PublicKey(string: address)
-        return publicKey != nil
+        guard let publicKey = PublicKey(string: address) else {
+            return false
+        }
+        return publicKey.bytes.count == PublicKey.LENGTH
     }
 }

--- a/BlockchainSdkTests/Common/AddressTests.swift
+++ b/BlockchainSdkTests/Common/AddressTests.swift
@@ -498,6 +498,13 @@ class AddressesTests: XCTestCase {
         XCTAssertEqual(addrFromTangemKey.value, "BmAzxn8WLYU3gEw79ATUdSUkMT53MeS5LjapBQB8gTPJ")
         
         try XCTAssertEqual(addressesUtility.makeTrustWalletAddress(publicKey: edKey, for: blockchain), addrFromTangemKey.value)
+
+        // From WalletCore
+        XCTAssertTrue(service.validate("2gVkYWexTHR5Hb2aLeQN3tnngvWzisFKXDUPrgMHpdST")) // OK
+        XCTAssertFalse(service.validate("2gVkYWexTHR5Hb2aLeQN3tnngvWzisFKXDUPrgMHpdSl"))  // Contains invalid base-58 character
+        XCTAssertFalse(service.validate("2gVkYWexTHR5Hb2aLeQN3tnngvWzisFKXDUPrgMHpd")) // Is invalid length
+        
+        XCTAssertFalse(service.validate("0x6ECa00c52AFC728CDbF42E817d712e175bb23C7d")) // Ethereum address
     }
     
     func testPolkadot() throws {


### PR DESCRIPTION
В самой библиотеке такая "валидация". В итоге если base58 проверка не проходила то ключ все равно создавался с 0 байтов.

```
public struct PublicKey {
    public static let LENGTH = 32
    ...

    public init?(string: String) {
        guard string.utf8.count >= PublicKey.LENGTH else {
            return nil
        }
        self.init(bytes: Base58.decode(string))
    }

    public init?(bytes: [UInt8]?) {
        guard let bytes = bytes, bytes.count <= PublicKey.LENGTH else {
            return nil
        }
        self.bytes = bytes
    }
```