### PR TITLE
IOS-4851: Named accounts validation for NEAR blockchain

### DIFF
--- a/BlockchainSdk.xcodeproj/project.pbxproj
+++ b/BlockchainSdk.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 		B64B728C2AEC9C7B005C8C7C /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B64B728B2AEC9C7B005C8C7C /* Lock.swift */; };
 		B65D2E792AD9B208004DF330 /* NEARNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65D2E782AD9B208004DF330 /* NEARNetworkService.swift */; };
 		B68507082AEF494E004A431B /* NEARProtocolConfigCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68507072AEF494E004A431B /* NEARProtocolConfigCache.swift */; };
+		B69293752AEC6A2300D6A85A /* NEARTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69293742AEC6A2300D6A85A /* NEARTests.swift */; };
 		B6B083572AE6B11C0099D6F8 /* NEARAccessKeyInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B083552AE6B11C0099D6F8 /* NEARAccessKeyInfo.swift */; };
 		B6B083582AE6B11C0099D6F8 /* NEARProtocolConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B083562AE6B11C0099D6F8 /* NEARProtocolConfig.swift */; };
 		B6B0835A2AE6B1480099D6F8 /* NEARAccountInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B083592AE6B1480099D6F8 /* NEARAccountInfo.swift */; };
@@ -745,6 +746,7 @@
 		B64B728B2AEC9C7B005C8C7C /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		B65D2E782AD9B208004DF330 /* NEARNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARNetworkService.swift; sourceTree = "<group>"; };
 		B68507072AEF494E004A431B /* NEARProtocolConfigCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NEARProtocolConfigCache.swift; sourceTree = "<group>"; };
+		B69293742AEC6A2300D6A85A /* NEARTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARTests.swift; sourceTree = "<group>"; };
 		B6B083552AE6B11C0099D6F8 /* NEARAccessKeyInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NEARAccessKeyInfo.swift; sourceTree = "<group>"; };
 		B6B083562AE6B11C0099D6F8 /* NEARProtocolConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NEARProtocolConfig.swift; sourceTree = "<group>"; };
 		B6B083592AE6B1480099D6F8 /* NEARAccountInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARAccountInfo.swift; sourceTree = "<group>"; };
@@ -1873,6 +1875,7 @@
 		B63E7DBA2AE9FD91000324CB /* NEAR */ = {
 			isa = PBXGroup;
 			children = (
+				B69293742AEC6A2300D6A85A /* NEARTests.swift */,
 			);
 			path = NEAR;
 			sourceTree = "<group>";
@@ -1902,6 +1905,7 @@
 			children = (
 				B6BA93682AEA0DEC00F84E36 /* Params */,
 				B6BA93692AEA0DF000F84E36 /* Result */,
+				B641EC4A2AEF729600B44CF8 /* Extensions */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -3079,6 +3083,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2DC5796129C9CBB1004312AE /* WalletCoreSignerTesterUtility.swift in Sources */,
+				B69293752AEC6A2300D6A85A /* NEARTests.swift in Sources */,
 				B00DEAD128FFDE0E0077CD19 /* TransactionSizeTesterUtility.swift in Sources */,
 				DA63B08D29CB3FAF00AC6E49 /* KaspaTests.swift in Sources */,
 				2DBBE95029C8DBEA00971539 /* TONTests.swift in Sources */,

--- a/BlockchainSdk.xcodeproj/project.pbxproj
+++ b/BlockchainSdk.xcodeproj/project.pbxproj
@@ -229,6 +229,7 @@
 		B63B792D2AD850DF0055BD06 /* NEARWalletAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63B792C2AD850DF0055BD06 /* NEARWalletAssembly.swift */; };
 		B63B792F2AD852E80055BD06 /* NEARExternalLinkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63B792E2AD852E80055BD06 /* NEARExternalLinkProvider.swift */; };
 		B641EC492AEF5CC100B44CF8 /* NEARAddressUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = B641EC482AEF5CC100B44CF8 /* NEARAddressUtil.swift */; };
+		B641EC4C2AEF72AA00B44CF8 /* NEARNetworkResult.APIError+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B641EC4B2AEF72AA00B44CF8 /* NEARNetworkResult.APIError+.swift */; };
 		B64B728C2AEC9C7B005C8C7C /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B64B728B2AEC9C7B005C8C7C /* Lock.swift */; };
 		B65D2E792AD9B208004DF330 /* NEARNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65D2E782AD9B208004DF330 /* NEARNetworkService.swift */; };
 		B68507082AEF494E004A431B /* NEARProtocolConfigCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68507072AEF494E004A431B /* NEARProtocolConfigCache.swift */; };
@@ -744,6 +745,7 @@
 		B63B792C2AD850DF0055BD06 /* NEARWalletAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARWalletAssembly.swift; sourceTree = "<group>"; };
 		B63B792E2AD852E80055BD06 /* NEARExternalLinkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARExternalLinkProvider.swift; sourceTree = "<group>"; };
 		B641EC482AEF5CC100B44CF8 /* NEARAddressUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARAddressUtil.swift; sourceTree = "<group>"; };
+		B641EC4B2AEF72AA00B44CF8 /* NEARNetworkResult.APIError+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NEARNetworkResult.APIError+.swift"; sourceTree = "<group>"; };
 		B64B728B2AEC9C7B005C8C7C /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		B65D2E782AD9B208004DF330 /* NEARNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARNetworkService.swift; sourceTree = "<group>"; };
 		B68507072AEF494E004A431B /* NEARProtocolConfigCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NEARProtocolConfigCache.swift; sourceTree = "<group>"; };
@@ -1883,6 +1885,14 @@
 			path = NEAR;
 			sourceTree = "<group>";
 		};
+		B641EC4A2AEF729600B44CF8 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				B641EC4B2AEF72AA00B44CF8 /* NEARNetworkResult.APIError+.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		B65D2E772AD9B1ED004DF330 /* Network */ = {
 			isa = PBXGroup;
 			children = (
@@ -2960,6 +2970,7 @@
 				DA656FC62952091A0092CC61 /* BlockBookConfig.swift in Sources */,
 				5D26CEF3243CB9FB00994CC0 /* BlockchainInfoTarget.swift in Sources */,
 				5DEC90C12587A35800826C95 /* BlockchainSdkConfig.swift in Sources */,
+				B641EC4C2AEF72AA00B44CF8 /* NEARNetworkResult.APIError+.swift in Sources */,
 				5D7D243925136254001B9A4F /* IssuedAmount.swift in Sources */,
 				5DF8D5B5243DB80C00186BF0 /* CardanoAddressService.swift in Sources */,
 				EF3FFFFD2A27740400C6E7D9 /* AdaliteUnspentOutputResponseDTO.swift in Sources */,

--- a/BlockchainSdk.xcodeproj/project.pbxproj
+++ b/BlockchainSdk.xcodeproj/project.pbxproj
@@ -230,7 +230,6 @@
 		B63B792D2AD850DF0055BD06 /* NEARWalletAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63B792C2AD850DF0055BD06 /* NEARWalletAssembly.swift */; };
 		B63B792F2AD852E80055BD06 /* NEARExternalLinkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63B792E2AD852E80055BD06 /* NEARExternalLinkProvider.swift */; };
 		B641EC492AEF5CC100B44CF8 /* NEARAddressUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = B641EC482AEF5CC100B44CF8 /* NEARAddressUtil.swift */; };
-		B641EC4C2AEF72AA00B44CF8 /* NEARNetworkResult.APIError+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B641EC4B2AEF72AA00B44CF8 /* NEARNetworkResult.APIError+.swift */; };
 		B64B728C2AEC9C7B005C8C7C /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B64B728B2AEC9C7B005C8C7C /* Lock.swift */; };
 		B65D2E792AD9B208004DF330 /* NEARNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65D2E782AD9B208004DF330 /* NEARNetworkService.swift */; };
 		B68507082AEF494E004A431B /* NEARProtocolConfigCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68507072AEF494E004A431B /* NEARProtocolConfigCache.swift */; };
@@ -751,7 +750,6 @@
 		B63B792C2AD850DF0055BD06 /* NEARWalletAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARWalletAssembly.swift; sourceTree = "<group>"; };
 		B63B792E2AD852E80055BD06 /* NEARExternalLinkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARExternalLinkProvider.swift; sourceTree = "<group>"; };
 		B641EC482AEF5CC100B44CF8 /* NEARAddressUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARAddressUtil.swift; sourceTree = "<group>"; };
-		B641EC4B2AEF72AA00B44CF8 /* NEARNetworkResult.APIError+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NEARNetworkResult.APIError+.swift"; sourceTree = "<group>"; };
 		B64B728B2AEC9C7B005C8C7C /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		B65D2E782AD9B208004DF330 /* NEARNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARNetworkService.swift; sourceTree = "<group>"; };
 		B68507072AEF494E004A431B /* NEARProtocolConfigCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NEARProtocolConfigCache.swift; sourceTree = "<group>"; };
@@ -1897,14 +1895,6 @@
 			path = NEAR;
 			sourceTree = "<group>";
 		};
-		B641EC4A2AEF729600B44CF8 /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				B641EC4B2AEF72AA00B44CF8 /* NEARNetworkResult.APIError+.swift */,
-			);
-			path = Extensions;
-			sourceTree = "<group>";
-		};
 		B65D2E772AD9B1ED004DF330 /* Network */ = {
 			isa = PBXGroup;
 			children = (
@@ -1932,7 +1922,6 @@
 				B6BA93682AEA0DEC00F84E36 /* Params */,
 				B6BA93692AEA0DF000F84E36 /* Result */,
 				B6E7699D2AF2D05A00B32745 /* Extensions */,
-				B641EC4A2AEF729600B44CF8 /* Extensions */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -2997,7 +2986,6 @@
 				5D26CEF3243CB9FB00994CC0 /* BlockchainInfoTarget.swift in Sources */,
 				5DEC90C12587A35800826C95 /* BlockchainSdkConfig.swift in Sources */,
 				B6E7699A2AF2CFBC00B32745 /* NEARTransactionsInfo.swift in Sources */,
-				B641EC4C2AEF72AA00B44CF8 /* NEARNetworkResult.APIError+.swift in Sources */,
 				5D7D243925136254001B9A4F /* IssuedAmount.swift in Sources */,
 				5DF8D5B5243DB80C00186BF0 /* CardanoAddressService.swift in Sources */,
 				EF3FFFFD2A27740400C6E7D9 /* AdaliteUnspentOutputResponseDTO.swift in Sources */,

--- a/BlockchainSdk.xcodeproj/project.pbxproj
+++ b/BlockchainSdk.xcodeproj/project.pbxproj
@@ -228,6 +228,7 @@
 		B62A12062AE308DA0080BAEC /* NEARTransactionParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62A12052AE308DA0080BAEC /* NEARTransactionParams.swift */; };
 		B63B792D2AD850DF0055BD06 /* NEARWalletAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63B792C2AD850DF0055BD06 /* NEARWalletAssembly.swift */; };
 		B63B792F2AD852E80055BD06 /* NEARExternalLinkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63B792E2AD852E80055BD06 /* NEARExternalLinkProvider.swift */; };
+		B641EC492AEF5CC100B44CF8 /* NEARAddressUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = B641EC482AEF5CC100B44CF8 /* NEARAddressUtil.swift */; };
 		B64B728C2AEC9C7B005C8C7C /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B64B728B2AEC9C7B005C8C7C /* Lock.swift */; };
 		B65D2E792AD9B208004DF330 /* NEARNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65D2E782AD9B208004DF330 /* NEARNetworkService.swift */; };
 		B68507082AEF494E004A431B /* NEARProtocolConfigCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68507072AEF494E004A431B /* NEARProtocolConfigCache.swift */; };
@@ -740,6 +741,7 @@
 		B62A12052AE308DA0080BAEC /* NEARTransactionParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARTransactionParams.swift; sourceTree = "<group>"; };
 		B63B792C2AD850DF0055BD06 /* NEARWalletAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARWalletAssembly.swift; sourceTree = "<group>"; };
 		B63B792E2AD852E80055BD06 /* NEARExternalLinkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARExternalLinkProvider.swift; sourceTree = "<group>"; };
+		B641EC482AEF5CC100B44CF8 /* NEARAddressUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARAddressUtil.swift; sourceTree = "<group>"; };
 		B64B728B2AEC9C7B005C8C7C /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		B65D2E782AD9B208004DF330 /* NEARNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARNetworkService.swift; sourceTree = "<group>"; };
 		B68507072AEF494E004A431B /* NEARProtocolConfigCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NEARProtocolConfigCache.swift; sourceTree = "<group>"; };
@@ -1861,6 +1863,7 @@
 				B65D2E772AD9B1ED004DF330 /* Network */,
 				B6D345F52AD8B4A50009D1B2 /* NEARWalletManager.swift */,
 				B68507072AEF494E004A431B /* NEARProtocolConfigCache.swift */,
+				B641EC482AEF5CC100B44CF8 /* NEARAddressUtil.swift */,
 				B6D345FF2AD9450D0009D1B2 /* NEARTransactionBuilder.swift */,
 				B62A12052AE308DA0080BAEC /* NEARTransactionParams.swift */,
 			);
@@ -2894,6 +2897,7 @@
 				EF3B19322AA85CDD0084AA1C /* TezosExternalLinkProvider.swift in Sources */,
 				2D9A91A229BB8C1700476EA6 /* TONProviderResponse.swift in Sources */,
 				B056729B2570F9DC00A8CB59 /* BlockchainSdkError.swift in Sources */,
+				B641EC492AEF5CC100B44CF8 /* NEARAddressUtil.swift in Sources */,
 				EF32FEE02A38D43A002ED43F /* BitcoinScriptAddressesProvider.swift in Sources */,
 				B6BA937B2AEA0F1D00F84E36 /* NEARNetworkResult.ProtocolConfig.swift in Sources */,
 				DADF5F932A1B7C6B00D58DC3 /* TWPublicKey+.swift in Sources */,

--- a/BlockchainSdk.xcodeproj/project.pbxproj
+++ b/BlockchainSdk.xcodeproj/project.pbxproj
@@ -252,6 +252,7 @@
 		B6D345F82AD8B8040009D1B2 /* NEARNetworkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D345F72AD8B8040009D1B2 /* NEARNetworkProvider.swift */; };
 		B6D346002AD9450D0009D1B2 /* NEARTransactionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D345FF2AD9450D0009D1B2 /* NEARTransactionBuilder.swift */; };
 		B6D7131F2AEBEF750095FE6A /* NEARNetworkResult.APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D7131E2AEBEF750095FE6A /* NEARNetworkResult.APIError.swift */; };
+		B6E9F3F32AEF5A8E00209FCA /* NEARAddressService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E9F3F22AEF5A8E00209FCA /* NEARAddressService.swift */; };
 		B6F3AA6D2ADD92230059C99A /* Publisher+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F3AA6B2ADD92230059C99A /* Publisher+.swift */; };
 		B6F3AA6E2ADD92230059C99A /* Moya+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F3AA6C2ADD92230059C99A /* Moya+.swift */; };
 		B6F3AA712ADD925D0059C99A /* NEARNetworkParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F3AA6F2ADD925D0059C99A /* NEARNetworkParams.swift */; };
@@ -766,6 +767,7 @@
 		B6D345F72AD8B8040009D1B2 /* NEARNetworkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARNetworkProvider.swift; sourceTree = "<group>"; };
 		B6D345FF2AD9450D0009D1B2 /* NEARTransactionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARTransactionBuilder.swift; sourceTree = "<group>"; };
 		B6D7131E2AEBEF750095FE6A /* NEARNetworkResult.APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARNetworkResult.APIError.swift; sourceTree = "<group>"; };
+		B6E9F3F22AEF5A8E00209FCA /* NEARAddressService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARAddressService.swift; sourceTree = "<group>"; };
 		B6F3AA6B2ADD92230059C99A /* Publisher+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Publisher+.swift"; sourceTree = "<group>"; };
 		B6F3AA6C2ADD92230059C99A /* Moya+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Moya+.swift"; sourceTree = "<group>"; };
 		B6F3AA6F2ADD925D0059C99A /* NEARNetworkParams.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NEARNetworkParams.swift; sourceTree = "<group>"; };
@@ -1865,6 +1867,7 @@
 				B65D2E772AD9B1ED004DF330 /* Network */,
 				B6D345F52AD8B4A50009D1B2 /* NEARWalletManager.swift */,
 				B68507072AEF494E004A431B /* NEARProtocolConfigCache.swift */,
+				B6E9F3F22AEF5A8E00209FCA /* NEARAddressService.swift */,
 				B641EC482AEF5CC100B44CF8 /* NEARAddressUtil.swift */,
 				B6D345FF2AD9450D0009D1B2 /* NEARTransactionBuilder.swift */,
 				B62A12052AE308DA0080BAEC /* NEARTransactionParams.swift */,
@@ -3014,6 +3017,7 @@
 				DAED921F27A150E500F188D7 /* PolkadotAddressService.swift in Sources */,
 				5D4B33CD23F7DC0400C93A84 /* BinanceWalletManager.swift in Sources */,
 				5D0906C227DBB7A10053B2CD /* BitcoinCashNetworkParams.swift in Sources */,
+				B6E9F3F32AEF5A8E00209FCA /* NEARAddressService.swift in Sources */,
 				B07EE8B225AC1504009DB163 /* DateFormatter+.swift in Sources */,
 				5D557CB523ACCAD2009B32AF /* BlockcypherNetworkProvider.swift in Sources */,
 				5D7D243725136254001B9A4F /* XRPCurrentLedgerInfo.swift in Sources */,

--- a/BlockchainSdk/Common/Factories/AddressServiceFactory.swift
+++ b/BlockchainSdk/Common/Factories/AddressServiceFactory.swift
@@ -93,7 +93,7 @@ public struct AddressServiceFactory {
         case .chia:
             return ChiaAddressService(isTestnet: isTestnet)
         case .near:
-            return NEARAddressService(blockchain: blockchain)
+            return NEARAddressService()
         }
     }
 }

--- a/BlockchainSdk/Common/Factories/AddressServiceFactory.swift
+++ b/BlockchainSdk/Common/Factories/AddressServiceFactory.swift
@@ -86,13 +86,14 @@ public struct AddressServiceFactory {
         case .ton,
                 .cosmos,
                 .terraV1,
-                .terraV2,
-                .near:
+                .terraV2:
             return WalletCoreAddressService(blockchain: blockchain)
         case .ducatus:
             return BitcoinLegacyAddressService(networkParams: DucatusNetworkParams())
         case .chia:
             return ChiaAddressService(isTestnet: isTestnet)
+        case .near:
+            return NEARAddressService(blockchain: blockchain)
         }
     }
 }

--- a/BlockchainSdk/Common/WalletManager.swift
+++ b/BlockchainSdk/Common/WalletManager.swift
@@ -106,8 +106,8 @@ public protocol WithdrawalValidator {
 }
 
 @available(iOS 13.0, *)
-public protocol AddressModifier {
-    func modify(_ address: String) async throws -> String
+public protocol AddressResolver {
+    func resolve(_ address: String) async throws -> String
 }
 
 public struct WithdrawalWarning {

--- a/BlockchainSdk/Common/WalletManager.swift
+++ b/BlockchainSdk/Common/WalletManager.swift
@@ -105,6 +105,11 @@ public protocol WithdrawalValidator {
     func validate(_ transaction: Transaction) -> WithdrawalWarning?
 }
 
+@available(iOS 13.0, *)
+public protocol AddressModifier {
+    func modify(_ address: String) async throws -> String
+}
+
 public struct WithdrawalWarning {
     public let warningMessage: String
     public let reduceMessage: String

--- a/BlockchainSdk/WalletManagers/NEAR/DTO/Extensions/NEARNetworkResult.APIError+.swift
+++ b/BlockchainSdk/WalletManagers/NEAR/DTO/Extensions/NEARNetworkResult.APIError+.swift
@@ -1,0 +1,15 @@
+//
+//  NEARNetworkResult.APIError+.swift
+//  BlockchainSdk
+//
+//  Created by Andrey Fedorov on 30.10.2023.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+extension NEARNetworkResult.APIError {
+    var isUnknownAccount: Bool {
+        return name == .handlerError && cause.name == .unknownAccount
+    }
+}

--- a/BlockchainSdk/WalletManagers/NEAR/NEARAddressService.swift
+++ b/BlockchainSdk/WalletManagers/NEAR/NEARAddressService.swift
@@ -1,0 +1,39 @@
+//
+//  NEARAddressService.swift
+//  BlockchainSdk
+//
+//  Created by Andrey Fedorov on 30.10.2023.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+final class NEARAddressService {
+    private let blockchain: Blockchain
+    private lazy var walletCoreAddressService = WalletCoreAddressService(blockchain: blockchain)
+
+    init(blockchain: Blockchain) {
+        self.blockchain = blockchain
+    }
+}
+
+
+// MARK: - AddressProvider protocol conformance
+
+extension NEARAddressService: AddressProvider {
+    func makeAddress(for publicKey: Wallet.PublicKey, with addressType: AddressType) throws -> PlainAddress {
+        return try walletCoreAddressService.makeAddress(for: publicKey, with: addressType)
+    }
+}
+
+// MARK: - AddressValidator protocol conformance
+
+extension NEARAddressService: AddressValidator {
+    func validate(_ address: String) -> Bool {
+        if NEARAddressUtil.isImplicitAccount(accountId: address) {
+            return walletCoreAddressService.validate(address)
+        }
+
+        return NEARAddressUtil.isValidNamedAccount(accountId: address)
+    }
+}

--- a/BlockchainSdk/WalletManagers/NEAR/NEARAddressService.swift
+++ b/BlockchainSdk/WalletManagers/NEAR/NEARAddressService.swift
@@ -17,7 +17,6 @@ final class NEARAddressService {
     }
 }
 
-
 // MARK: - AddressProvider protocol conformance
 
 extension NEARAddressService: AddressProvider {

--- a/BlockchainSdk/WalletManagers/NEAR/NEARAddressService.swift
+++ b/BlockchainSdk/WalletManagers/NEAR/NEARAddressService.swift
@@ -9,12 +9,7 @@
 import Foundation
 
 final class NEARAddressService {
-    private let blockchain: Blockchain
-    private lazy var walletCoreAddressService = WalletCoreAddressService(blockchain: blockchain)
-
-    init(blockchain: Blockchain) {
-        self.blockchain = blockchain
-    }
+    private lazy var walletCoreAddressService = WalletCoreAddressService(coin: .near)
 }
 
 // MARK: - AddressProvider protocol conformance

--- a/BlockchainSdk/WalletManagers/NEAR/NEARAddressUtil.swift
+++ b/BlockchainSdk/WalletManagers/NEAR/NEARAddressUtil.swift
@@ -1,0 +1,73 @@
+//
+//  NEARAddressUtil.swift
+//  BlockchainSdk
+//
+//  Created by Andrey Fedorov on 30.10.2023.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+/// See https://nomicon.io/DataStructures/Account#account-id-rules for information about implicit/named account IDs.
+enum NEARAddressUtil {
+    static func isImplicitAccount(accountId: String) -> Bool {
+        guard accountId.count == Constants.implicitAccountIdLength else {
+            return false
+        }
+
+        return accountId.isLowercasedHexStringWithoutPrefix
+    }
+
+    /// - Warning: In theory, every valid implicit account ID is also a valid named account ID (but not vise-versa).
+    /// Therefore, always first check whether the account ID is implicit or not, and only if it isn't,
+    /// consider it a named account and check its validity.
+    static func isValidNamedAccount(accountId: String) -> Bool {
+        return accountId.count >= Constants.namedAccountIdMinLength
+        && accountId.count <= Constants.namedAccountIdMaxLength
+        && accountId.matches(Constants.namedAccountIdRegex)
+        && accountId != Constants.systemAccountId
+    }
+}
+
+// MARK: - Constants
+
+private extension NEARAddressUtil {
+    enum Constants {
+        /// See https://nomicon.io/DataStructures/Account#system-account for details.
+        static let systemAccountId = "system"
+        static let implicitAccountIdLength = 64
+        static let namedAccountIdMinLength = 2
+        static let namedAccountIdMaxLength = implicitAccountIdLength
+        static let namedAccountIdRegex = try! NSRegularExpression(
+            pattern: "^(([a-z\\d]+[\\-_])*[a-z\\d]+\\.)*([a-z\\d]+[\\-_])*[a-z\\d]+$",
+            options: .anchorsMatchLines
+        )
+    }
+}
+
+// MARK: - Convenience extensions
+
+private extension String {
+    /// 0 through 9.
+    private static let asciiDecimalDigits: ClosedRange<UInt8> = UInt8(48)...UInt8(57)
+
+    /// a through f.
+    private static let asciiLowercaseHexDigits: ClosedRange<UInt8> = UInt8(97)...UInt8(102)
+
+    var isLowercasedHexStringWithoutPrefix: Bool {
+        return allSatisfy { character in
+            guard character.isASCII else {
+                return false
+            }
+
+            return Self.asciiDecimalDigits.contains(character.asciiValue!)
+            || Self.asciiLowercaseHexDigits.contains(character.asciiValue!)
+        }
+    }
+
+    func matches(_ regex: NSRegularExpression) -> Bool {
+        let range = NSRange(location: 0, length: utf16.count)
+
+        return regex.firstMatch(in: self, options: [], range: range) != nil
+    }
+}

--- a/BlockchainSdk/WalletManagers/NEAR/NEARAddressUtil.swift
+++ b/BlockchainSdk/WalletManagers/NEAR/NEARAddressUtil.swift
@@ -19,7 +19,7 @@ enum NEARAddressUtil {
     }
 
     /// - Warning: In theory, every valid implicit account ID is also a valid named account ID (but not vise-versa).
-    /// Therefore, always first check whether the account ID is implicit or not, and only if it isn't,
+    /// Therefore, always check whether the account ID is implicit or not first, and only if it isn't,
     /// consider it a named account and check its validity.
     static func isValidNamedAccount(accountId: String) -> Bool {
         return accountId.count >= Constants.namedAccountIdMinLength

--- a/BlockchainSdk/WalletManagers/NEAR/NEARWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/NEAR/NEARWalletManager.swift
@@ -78,7 +78,7 @@ final class NEARWalletManager: BaseManager {
     private func makeNoAccountError(using protocolConfig: NEARProtocolConfig) -> WalletError {
         let networkName = wallet.blockchain.displayName
         let decimalValue = wallet.blockchain.decimalValue
-        let reserveValue = Constants.accountStorageUsageInBytes * protocolConfig.storageAmountPerByte / decimalValue
+        let reserveValue = Constants.accountDefaultStorageUsageInBytes * protocolConfig.storageAmountPerByte / decimalValue
         let reserveValueString = reserveValue.decimalNumber.stringValue
         let currencySymbol = wallet.blockchain.currencySymbol
         let errorMessage = "no_account_generic".localized(networkName, reserveValueString, currencySymbol)
@@ -101,17 +101,6 @@ final class NEARWalletManager: BaseManager {
                 .eraseToAnyPublisher()
         }
         .eraseToAnyPublisher()
-    }
-
-    /// See https://nomicon.io/DataStructures/Account#account-id-rules for infomation about implicit/named account IDs.
-    private func isImplicitAccount(accountId: String) -> Bool {
-        guard accountId.count == Constants.implicitAccountAddressLength else {
-            return false
-        }
-
-        // `CharacterSet.alphanumerics` contains other non-ASCII characters, like diacritics, arabic, etc -
-        // so it can't be used to match the regex `[a-zA-Z\d]+`
-        return accountId.allSatisfy { $0.isASCII && $0.isHexDigit }
     }
 
     private func calculateBasicCostsSum(
@@ -138,7 +127,7 @@ final class NEARWalletManager: BaseManager {
         senderIsReceiver: Bool,
         destination: String
     ) -> Decimal {
-        guard isImplicitAccount(accountId: destination) else {
+        guard NEARAddressUtil.isImplicitAccount(accountId: destination) else {
             return .zero
         }
 
@@ -258,7 +247,6 @@ private extension NEARWalletManager {
         /// For newly created implicit accounts with a single access key (the default) we have to use this constant.
         /// See https://docs.near.org/integrator/accounts and
         /// https://pages.near.org/papers/economics-in-sharded-blockchain/#transaction-and-storage-fees for details.
-        static let accountStorageUsageInBytes: Decimal = 182
-        static let implicitAccountAddressLength = 64
+        static let accountDefaultStorageUsageInBytes: Decimal = 182
     }
 }

--- a/BlockchainSdk/WalletManagers/NEAR/NEARWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/NEAR/NEARWalletManager.swift
@@ -238,10 +238,10 @@ extension NEARWalletManager: WalletManager {
     }
 }
 
-// MARK: - AddressModifier protocol conformance
+// MARK: - AddressResolver protocol conformance
 
-extension NEARWalletManager: AddressModifier {
-    func modify(_ address: String) async throws -> String {
+extension NEARWalletManager: AddressResolver {
+    func resolve(_ address: String) async throws -> String {
         // Implicit accounts don't require any modification or verification
         if NEARAddressUtil.isImplicitAccount(accountId: address) {
             return address

--- a/BlockchainSdk/WalletManagers/NEAR/Network/NEARNetworkService.swift
+++ b/BlockchainSdk/WalletManagers/NEAR/Network/NEARNetworkService.swift
@@ -114,11 +114,7 @@ final class NEARNetworkService: MultiNetworkProvider {
                     )
                 }
                 .tryCatch { error in
-                    guard
-                        let apiError = error as? NEARNetworkResult.APIError,
-                        apiError.name == .handlerError,
-                        apiError.cause.name == .unknownAccount
-                    else {
+                    guard let apiError = error as? NEARNetworkResult.APIError, apiError.isUnknownAccount else {
                         throw error
                     }
 

--- a/BlockchainSdkTests/NEAR/NEARTests.swift
+++ b/BlockchainSdkTests/NEAR/NEARTests.swift
@@ -1,0 +1,98 @@
+//
+//  NEARTests.swift
+//  BlockchainSdkTests
+//
+//  Created by Andrey Fedorov on 28.10.2023.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+@testable import BlockchainSdk
+
+final class NEARTests: XCTestCase {
+    // Using example values from https://nomicon.io/DataStructures/Account#examples
+    func testAddressUtilImplicitAccountsDetection() {
+        XCTAssertTrue(NEARAddressUtil.isImplicitAccount(accountId: "f69cd39f654845e2059899a888681187f2cda95f29256329aea1700f50f8ae86"))
+        XCTAssertTrue(NEARAddressUtil.isImplicitAccount(accountId: "75149e81ac9ea0bcb6f00faee922f71a11271f6cbc55bac97753603504d7bf27"))
+        XCTAssertTrue(NEARAddressUtil.isImplicitAccount(accountId: "64acf5e86c840024032d7e75ec569a4d304443e250b197d5a0246d2d49afc8e1"))
+        XCTAssertTrue(NEARAddressUtil.isImplicitAccount(accountId: "84a3fe2fc0e585d802cfa160807d1bf8ca5f949cf8d04d128bf984c50aabab7b"))
+        XCTAssertTrue(NEARAddressUtil.isImplicitAccount(accountId: "d85d322043d87cc475d3523d6fb0c3df903d3830e5d4d5027ffe565e7b8652bb"))
+
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "f69cd39f654845e2059899a88868.1187f2cda95f29256329aea1700f50f8ae8"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "something.near"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: ""))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "6f8a1e9b0c2d3f4a5b7e8d9a1c32ed5f67b8cd0e1f23b4c5d6e7f88023a"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "9a4b6c1e2d8f3a5b7e8d9a1c3b2e4d5f6a7b8c9d0e1f2a3b4c5d6e7f8a4b6c1e2d8f3"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "ctiud11caxsb2tw7dmfcrhfw9ah15ltkydrjfblst32986pekmb3dsvyrmyym6qn"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "ok"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "bowen"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "ek-2"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "ek.near"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "com"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "google.com"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "bowen.google.com"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "near"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "illia.cheap-accounts.near"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "max_99.near"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "100"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "near2019"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "over.9000"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "a.bro"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "bro.a"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "not ok"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "a"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "100-"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "bo__wen"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "_illia"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: ".near"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "near."))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "a..near"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "$$$"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "WAT"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "me@google.com"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "system"))
+        XCTAssertFalse(NEARAddressUtil.isImplicitAccount(accountId: "abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz"))
+    }
+
+    // Using example values from https://nomicon.io/DataStructures/Account#examples
+    func testAddressUtilNamedAccountValidation() {
+        XCTAssertTrue(NEARAddressUtil.isValidNamedAccount(accountId: "f69cd39f654845e2059899a888681187f2cda95f29256329aea1700f50f8ae86"))
+        XCTAssertTrue(NEARAddressUtil.isValidNamedAccount(accountId: "f69cd39f654845e2059899a88868.1187f2cda95f29256329aea1700f50f8ae8"))
+        XCTAssertTrue(NEARAddressUtil.isValidNamedAccount(accountId: "something.near"))
+        XCTAssertTrue(NEARAddressUtil.isValidNamedAccount(accountId: "6f8a1e9b0c2d3f4a5b7e8d9a1c32ed5f67b8cd0e1f23b4c5d6e7f88023a"))
+        XCTAssertTrue(NEARAddressUtil.isValidNamedAccount(accountId: "ctiud11caxsb2tw7dmfcrhfw9ah15ltkydrjfblst32986pekmb3dsvyrmyym6qn"))
+        XCTAssertTrue(NEARAddressUtil.isValidNamedAccount(accountId: "ok"))
+        XCTAssertTrue(NEARAddressUtil.isValidNamedAccount(accountId: "bowen"))
+        XCTAssertTrue(NEARAddressUtil.isValidNamedAccount(accountId: "ek-2"))
+        XCTAssertTrue(NEARAddressUtil.isValidNamedAccount(accountId: "ek.near"))
+        XCTAssertTrue(NEARAddressUtil.isValidNamedAccount(accountId: "com"))
+        XCTAssertTrue(NEARAddressUtil.isValidNamedAccount(accountId: "google.com"))
+        XCTAssertTrue(NEARAddressUtil.isValidNamedAccount(accountId: "bowen.google.com"))
+        XCTAssertTrue(NEARAddressUtil.isValidNamedAccount(accountId: "near"))
+        XCTAssertTrue(NEARAddressUtil.isValidNamedAccount(accountId: "illia.cheap-accounts.near"))
+        XCTAssertTrue(NEARAddressUtil.isValidNamedAccount(accountId: "max_99.near"))
+        XCTAssertTrue(NEARAddressUtil.isValidNamedAccount(accountId: "100"))
+        XCTAssertTrue(NEARAddressUtil.isValidNamedAccount(accountId: "near2019"))
+        XCTAssertTrue(NEARAddressUtil.isValidNamedAccount(accountId: "over.9000"))
+        XCTAssertTrue(NEARAddressUtil.isValidNamedAccount(accountId: "a.bro"))
+        XCTAssertTrue(NEARAddressUtil.isValidNamedAccount(accountId: "bro.a"))
+
+        XCTAssertFalse(NEARAddressUtil.isValidNamedAccount(accountId: ""))
+        XCTAssertFalse(NEARAddressUtil.isValidNamedAccount(accountId: "9a4b6c1e2d8f3a5b7e8d9a1c3b2e4d5f6a7b8c9d0e1f2a3b4c5d6e7f8a4b6c1e2d8f3"))
+        XCTAssertFalse(NEARAddressUtil.isValidNamedAccount(accountId: "not ok"))
+        XCTAssertFalse(NEARAddressUtil.isValidNamedAccount(accountId: "a"))
+        XCTAssertFalse(NEARAddressUtil.isValidNamedAccount(accountId: "100-"))
+        XCTAssertFalse(NEARAddressUtil.isValidNamedAccount(accountId: "bo__wen"))
+        XCTAssertFalse(NEARAddressUtil.isValidNamedAccount(accountId: "_illia"))
+        XCTAssertFalse(NEARAddressUtil.isValidNamedAccount(accountId: ".near"))
+        XCTAssertFalse(NEARAddressUtil.isValidNamedAccount(accountId: "near."))
+        XCTAssertFalse(NEARAddressUtil.isValidNamedAccount(accountId: "a..near"))
+        XCTAssertFalse(NEARAddressUtil.isValidNamedAccount(accountId: "$$$"))
+        XCTAssertFalse(NEARAddressUtil.isValidNamedAccount(accountId: "WAT"))
+        XCTAssertFalse(NEARAddressUtil.isValidNamedAccount(accountId: "me@google.com"))
+        XCTAssertFalse(NEARAddressUtil.isValidNamedAccount(accountId: "system"))
+        XCTAssertFalse(NEARAddressUtil.isValidNamedAccount(accountId: "abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz"))
+    }
+}


### PR DESCRIPTION
[IOS-4851](https://tangem.atlassian.net/browse/IOS-4851)

Аккаунты с named id (которые не hex строка 64 символа), в отличии от аккаунтов с implicit id (hex строка 64 символа) - не могут быть созданы путем отправки на них денег.
Поэтому для named account IDs необходима валидация, как локальная (`NEARAddressUtil`), так и через апишку - что аккаунт уже создан 

Пулл в апп: https://github.com/tangem/tangem-app-ios/pull/2323

[IOS-4851]: https://tangem.atlassian.net/browse/IOS-4851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ