### PR TITLE
IOS-5360: Remove not supported Infura NEAR RPC endpoint

### DIFF
--- a/BlockchainSdk/Common/WalletAssembly/NEARWalletAssembly.swift
+++ b/BlockchainSdk/Common/WalletAssembly/NEARWalletAssembly.swift
@@ -41,7 +41,6 @@ struct NEARWalletAssembly: WalletManagerAssembly {
                     "https://rpc.mainnet.near.org",
                     "https://near.nownodes.io/\(sdkConfig.nowNodesApiKey)",
                     "https://near.getblock.io/\(sdkConfig.getBlockApiKey)",
-                    "https://near-mainnet.infura.io/v3/\(sdkConfig.infuraProjectId)",
                 ]
             )
         }


### PR DESCRIPTION
[IOS-5360](https://tangem.atlassian.net/browse/IOS-5360)

Infura удалила апишку для NEAR на своей стороне https://docs.infura.io/whats-new-in-the-docs#december-2023

[IOS-5360]: https://tangem.atlassian.net/browse/IOS-5360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ