### PR TITLE
IOS-5118 Use UInt64 instead of Int

### DIFF
--- a/BlockchainSdk/WalletManagers/Ethereum/EthereumWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/Ethereum/EthereumWalletManager.swift
@@ -133,7 +133,8 @@ private extension EthereumWalletManager {
 
                     // TODO: Fix integer overflow. Think about BigInt
                     // https://tangem.atlassian.net/browse/IOS-4268
-                    let fee = Decimal(Int(feeValue)) / decimalValue
+                    // https://tangem.atlassian.net/browse/IOS-5119
+                    let fee = Decimal(UInt64(feeValue)) / decimalValue
 
                     let amount = Amount(with: blockchain, value: fee)
                     let parameters = EthereumFeeParameters(gasLimit: gasLimit, gasPrice: gasPrice)

--- a/BlockchainSdkTests/Common/CommonTests.swift
+++ b/BlockchainSdkTests/Common/CommonTests.swift
@@ -9,6 +9,7 @@
 import Foundation
 import XCTest
 import TangemSdk
+import BigInt
 
 @testable import BlockchainSdk
 
@@ -23,5 +24,12 @@ class CommonTests: XCTestCase {
         XCTAssertEqual("0xaabbccdd".removeHexPrefix(), "aabbccdd")
         XCTAssertEqual("0xAABBCCdd".removeHexPrefix(), "AABBCCdd")
         XCTAssertEqual("AABBCCdd".removeHexPrefix(), "AABBCCdd")
+    }
+
+    func testOverflow() {
+        let max = BigUInt(18446744073709551615)
+        let eth = Blockchain.ethereum(testnet: false)
+        let calculated = Decimal(UInt64(max)) / eth.decimalValue
+        XCTAssertEqual(calculated, 18.446744073709551615)
     }
 }

--- a/BlockchainSdkTests/Common/CommonTests.swift
+++ b/BlockchainSdkTests/Common/CommonTests.swift
@@ -30,6 +30,7 @@ class CommonTests: XCTestCase {
         let max = BigUInt(18446744073709551615)
         let eth = Blockchain.ethereum(testnet: false)
         let calculated = Decimal(UInt64(max)) / eth.decimalValue
-        XCTAssertEqual(calculated, 18.446744073709551615)
+        let estimated = Decimal(string: "18.446744073709551615")
+        XCTAssertEqual(calculated, estimated)
     }
 }


### PR DESCRIPTION
Поменял Int на Uint64, потому что по коду выше используется именно BigUInt. Так гарантированно влезет при конвертации, а если уж в BigUInt не влезет, то и упадет выше. Сейчас падает как раз в строке конвертации, следовательно при перемножении в BigUInt влезает