### PR TITLE
IOS-5629 Fix blockchypher mapping

### DIFF
--- a/BlockchainSdk/BlockchainService/Blockcypher/BlockcypherNetworkProvider.swift
+++ b/BlockchainSdk/BlockchainService/Blockcypher/BlockcypherNetworkProvider.swift
@@ -93,7 +93,7 @@ class BlockcypherNetworkProvider: BitcoinNetworkProvider {
     
     func send(transaction: String) -> AnyPublisher<String, Error> {
         publisher(for: getTarget(for: .send(txHex: transaction), withRandomToken: true))
-            .map(BlockcypherSendResponse.self)
+            .map(BlockcypherSendResponse.self, using: jsonDecoder)
             .eraseError()
             .map { $0.tx.hash }
             .eraseToAnyPublisher()

--- a/BlockchainSdk/BlockchainService/Blockcypher/BlockcypherResponse.swift
+++ b/BlockchainSdk/BlockchainService/Blockcypher/BlockcypherResponse.swift
@@ -255,5 +255,11 @@ struct BlockcypherEthereumTransaction: Codable, BlockcypherPendingTxConvertible 
 
 
 struct BlockcypherSendResponse: Decodable {
-    let tx: BlockcypherBitcoinTx
+    let tx: BlockcypherBitcoinSendTx
+}
+
+extension BlockcypherSendResponse {
+    struct BlockcypherBitcoinSendTx: Decodable {
+        let hash: String
+    }
 }

--- a/BlockchainSdk/WalletManagers/VeChain/Network/VeChainNetworkService.swift
+++ b/BlockchainSdk/WalletManagers/VeChain/Network/VeChainNetworkService.swift
@@ -64,12 +64,12 @@ final class VeChainNetworkService: MultiNetworkProvider {
                 .tryMap { transactionStatus in
                     switch transactionStatus {
                     case .parsed(let parsedStatus):
-                        VeChainTransactionInfo(transactionHash: parsedStatus.id)
+                        return VeChainTransactionInfo(transactionHash: parsedStatus.id)
                     case .raw:
                         // `raw` output can't be easily parsed and therefore not supported
                         throw WalletError.failedToParseNetworkResponse
                     case .notFound:
-                        VeChainTransactionInfo(transactionHash: nil)
+                        return VeChainTransactionInfo(transactionHash: nil)
                     }
                 }
                 .eraseToAnyPublisher()


### PR DESCRIPTION
Проблема была в отсутствии кастомного декодера для Date. Дополнительно перестраховался, убрав из маппинга все ненужные поля, но и кастомный декодер оставил, на случай, если понадобятся дополнительные поля