### PR TITLE
IOS-5650: Add `feePaidCurrency` method

### DIFF
--- a/BlockchainSdk.xcodeproj/project.pbxproj
+++ b/BlockchainSdk.xcodeproj/project.pbxproj
@@ -256,6 +256,7 @@
 		B68A7D472B35D39700822BAF /* VeChainTransactionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68A7D462B35D39700822BAF /* VeChainTransactionInfo.swift */; };
 		B69293752AEC6A2300D6A85A /* NEARTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69293742AEC6A2300D6A85A /* NEARTests.swift */; };
 		B6931AD32B32495C00B31319 /* VeChainAccountInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6931AD22B32495C00B31319 /* VeChainAccountInfo.swift */; };
+		B6A71D982B553E7900039991 /* FeePaidCurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A71D972B553E7900039991 /* FeePaidCurrency.swift */; };
 		B6A7A91B2B318DA50053DCF7 /* VeChainTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7A91A2B318DA50053DCF7 /* VeChainTarget.swift */; };
 		B6A7A91D2B318FBE0053DCF7 /* VeChainBaseURLProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7A91C2B318FBE0053DCF7 /* VeChainBaseURLProvider.swift */; };
 		B6AF184D2AF00F8600113BC2 /* TWCurve+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AF184C2AF00F8600113BC2 /* TWCurve+.swift */; };
@@ -909,6 +910,7 @@
 		B68A7D462B35D39700822BAF /* VeChainTransactionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VeChainTransactionInfo.swift; sourceTree = "<group>"; };
 		B69293742AEC6A2300D6A85A /* NEARTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEARTests.swift; sourceTree = "<group>"; };
 		B6931AD22B32495C00B31319 /* VeChainAccountInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VeChainAccountInfo.swift; sourceTree = "<group>"; };
+		B6A71D972B553E7900039991 /* FeePaidCurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeePaidCurrency.swift; sourceTree = "<group>"; };
 		B6A7A91A2B318DA50053DCF7 /* VeChainTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VeChainTarget.swift; sourceTree = "<group>"; };
 		B6A7A91C2B318FBE0053DCF7 /* VeChainBaseURLProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VeChainBaseURLProvider.swift; sourceTree = "<group>"; };
 		B6AF184C2AF00F8600113BC2 /* TWCurve+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TWCurve+.swift"; sourceTree = "<group>"; };
@@ -1616,6 +1618,7 @@
 				EFBA17FD2988623F00C23955 /* TransactionSendResult.swift */,
 				2D9A91A629BB8C2E00476EA6 /* WalletCoreAddressService.swift */,
 				EF5F1B9629C9C0500093307B /* Fee.swift */,
+				B6A71D972B553E7900039991 /* FeePaidCurrency.swift */,
 				2DA8AB0C2A433A1000C75D85 /* ExceptionHandler.swift */,
 				EFEADBDD2A4D737F00744407 /* SignatureInfo.swift */,
 				EFF466E72ACD851700ACC3EA /* PendingTransactionRecord.swift */,
@@ -3682,6 +3685,7 @@
 				2DBBE94D29C8686000971539 /* OptimismWalletAssembly.swift in Sources */,
 				B6D346002AD9450D0009D1B2 /* NEARTransactionBuilder.swift in Sources */,
 				EF5F1B9729C9C0500093307B /* Fee.swift in Sources */,
+				B6A71D982B553E7900039991 /* FeePaidCurrency.swift in Sources */,
 				DC5E65042B1650F400E81AA5 /* OP_NUMEQUAL.swift in Sources */,
 				DA82433F27A2B07800CFC2C0 /* PolkadotNetwork.swift in Sources */,
 				5D7D243025136254001B9A4F /* XRPKeypair.swift in Sources */,

--- a/BlockchainSdk/Common/Blockchain.swift
+++ b/BlockchainSdk/Common/Blockchain.swift
@@ -405,6 +405,17 @@ public enum Blockchain: Equatable, Hashable {
         
         return false
     }
+
+    public func feePaidCurrency(for amountType: Amount.AmountType) -> FeePaidCurrency {
+        switch self {
+        case .terraV1:
+            return .sameCurrency
+        case .veChain:
+            return .token(value: VeChainWalletManager.Constants.energyToken)
+        default:
+            return .coin
+        }
+    }
 }
 
 // MARK: - Ethereum based blockchain definition

--- a/BlockchainSdk/Common/Blockchain.swift
+++ b/BlockchainSdk/Common/Blockchain.swift
@@ -381,6 +381,17 @@ public enum Blockchain: Equatable, Hashable {
         }
     }
     
+    public var feePaidCurrency: FeePaidCurrency {
+        switch self {
+        case .terraV1:
+            return .sameCurrency
+        case .veChain:
+            return .token(value: VeChainWalletManager.Constants.energyToken)
+        default:
+            return .coin
+        }
+    }
+
     public func isFeeApproximate(for amountType: Amount.AmountType) -> Bool {
         switch self {
         case .arbitrum,
@@ -404,17 +415,6 @@ public enum Blockchain: Equatable, Hashable {
         }
         
         return false
-    }
-
-    public func feePaidCurrency(for amountType: Amount.AmountType) -> FeePaidCurrency {
-        switch self {
-        case .terraV1:
-            return .sameCurrency
-        case .veChain:
-            return .token(value: VeChainWalletManager.Constants.energyToken)
-        default:
-            return .coin
-        }
     }
 }
 

--- a/BlockchainSdk/Common/FeePaidCurrency.swift
+++ b/BlockchainSdk/Common/FeePaidCurrency.swift
@@ -1,0 +1,19 @@
+//
+//  FeePaidCurrency.swift
+//  BlockchainSdk
+//
+//  Created by Andrey Fedorov on 15.01.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+/// The currency that is used to pay the transaction fees.
+public enum FeePaidCurrency {
+    /// Fees are paid in the network's main currency.
+    case coin
+    /// Fees are paid in the specific token of this network.
+    case token(value: Token)
+    /// Fees are paid in the same currency in which the transaction was made.
+    case sameCurrency
+}

--- a/BlockchainSdk/WalletManagers/VeChain/VeChainWalletManager.swift
+++ b/BlockchainSdk/WalletManagers/VeChain/VeChainWalletManager.swift
@@ -240,7 +240,7 @@ extension VeChainWalletManager: WalletManager {
 
 // MARK: - Constants
 
-private extension VeChainWalletManager {
+extension VeChainWalletManager {
     enum Constants {
         /// A local energy token ("VeThor"), used as a fallback for fee calculation when
         /// the user doesn't have a real "VeThor" token added to the token list.


### PR DESCRIPTION
[IOS-5650](https://tangem.atlassian.net/browse/IOS-5650)

Нужно во многих местах в аппе для корректной работы разных проверок в случае сетки типа Vechain, где комса платится всегда в токенах.

[IOS-5650]: https://tangem.atlassian.net/browse/IOS-5650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ