### PR TITLE
IOS-5709: Fix `Hashable` & `Equatable` conformance for `Amount.AmountType`

### DIFF
--- a/BlockchainSdk/Common/Amount.swift
+++ b/BlockchainSdk/Common/Amount.swift
@@ -178,11 +178,6 @@ extension Amount.AmountType: Hashable {
 }
 
 extension Amount {
-    static func dummyCoin(for blockchain: Blockchain) -> Amount {
-        // TODO: Andrey Fedorov - Implementation is the same as `zeroCoin(for:)` (IOS-4990)
-        Amount(with: blockchain, type: .coin, value: 0)
-    }
-    
     public static func zeroCoin(for blockchain: Blockchain) -> Amount {
         .init(with: blockchain, type: .coin, value: 0)
     }

--- a/BlockchainSdk/Common/Amount.swift
+++ b/BlockchainSdk/Common/Amount.swift
@@ -170,7 +170,7 @@ extension Amount.AmountType: Hashable {
         case (.coin, .coin), (.reserve, .reserve):
             return true
         case (.token(let lv), .token(let rv)):
-            return lv == rv && lv.symbol == rv.symbol
+            return lv == rv
         default:
             return false
         }

--- a/BlockchainSdk/Common/Amount.swift
+++ b/BlockchainSdk/Common/Amount.swift
@@ -161,22 +161,16 @@ extension Amount.AmountType: Hashable {
         case .reserve:
             hasher.combine("reserve")
         case .token(let value):
-            hasher.combine(value.hashValue)
+            hasher.combine(value)
         }
     }
     
     public static func == (lhs: Amount.AmountType, rhs: Amount.AmountType) -> Bool {
         switch (lhs, rhs) {
-        case (.coin, .coin):
-            return true
-        case (.reserve, .reserve):
+        case (.coin, .coin), (.reserve, .reserve):
             return true
         case (.token(let lv), .token(let rv)):
-            if lv.symbol == rv.symbol,
-                lv.contractAddress == rv.contractAddress {
-                return true
-            }
-            return false
+            return lv == rv && lv.symbol == rv.symbol
         default:
             return false
         }

--- a/BlockchainSdkTests/NEAR/NEARTests.swift
+++ b/BlockchainSdkTests/NEAR/NEARTests.swift
@@ -125,7 +125,7 @@ final class NEARTests: XCTestCase {
         let destinationAddress = "jhj909.testnet"
         let value = try XCTUnwrap(Decimal(string: "3.891"))
         let amount = Amount(with: blockchain, value: value)
-        let fee = Fee(.dummyCoin(for: blockchain))  // Not used in the transaction, therefore a dummy value is used
+        let fee = Fee(.zeroCoin(for: blockchain))  // Not used in the transaction, therefore a dummy value is used
 
         let transactionParams = NEARTransactionParams(
             publicKey: publicKey,


### PR DESCRIPTION
[IOS-5709](https://tangem.atlassian.net/browse/IOS-5709)

В имплементации Hashable/Equatable у `Token` везде юзается `contractAddress.lowercased()`
У `Amount.AmountType` в его импле Equatable для токенов не юзается `lowercased()` для `contractAddress`

Это приводит к тому, что в случае коллизии хешей Equatable будет работать не так, как ожидается и проверка на равенство будет фейлится (что и обнаружилось при имплементации вичейна).

[IOS-5709]: https://tangem.atlassian.net/browse/IOS-5709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ