### PR TITLE
IOS-5773: Apply rounding down when converting tx amount from `Decimal` to `BigUInt`

### DIFF
--- a/BlockchainSdk/WalletManagers/VeChain/Network/VeChainNetworkService.swift
+++ b/BlockchainSdk/WalletManagers/VeChain/Network/VeChainNetworkService.swift
@@ -94,9 +94,10 @@ final class VeChainNetworkService: MultiNetworkProvider {
     }
 
     func getVMGas(token: Token, amount: Amount, source: String, destination: String) -> AnyPublisher<Int, Error> {
-        let decimalValue = (amount.value * pow(Decimal(10), amount.decimals)).roundedDecimalNumber
+        let decimalValue = amount.value * pow(Decimal(10), amount.decimals)
+        let roundedValue = decimalValue.rounded(roundingMode: .down)
 
-        guard let bigUIntValue = BigUInt(decimal: decimalValue as Decimal) else {
+        guard let bigUIntValue = BigUInt(decimal: roundedValue) else {
             return .anyFail(error: WalletError.failedToGetFee)
         }
 

--- a/BlockchainSdk/WalletManagers/VeChain/VeChainTransactionBuilder.swift
+++ b/BlockchainSdk/WalletManagers/VeChain/VeChainTransactionBuilder.swift
@@ -146,8 +146,9 @@ final class VeChainTransactionBuilder {
     private func transferValue(from transaction: Transaction) throws -> BigUInt {
         let amount = transaction.amount
         let decimalValue = amount.value * pow(Decimal(10), amount.decimals)
+        let roundedValue = decimalValue.rounded(roundingMode: .down)
 
-        guard let bigUIntValue = BigUInt(decimal: decimalValue) else {
+        guard let bigUIntValue = BigUInt(decimal: roundedValue) else {
             throw WalletError.failedToBuildTx
         }
 


### PR DESCRIPTION
https://tangem.atlassian.net/browse/IOS-5773

Исходный баг обнаружился при умножении tx amount на 10^decimals, получалось что-то вроде
`114424709097352968482.000000000000001`
это значение затем неуспешно конвертилось в BigUInt из-за наличия дробной части, кидая ошибку

Т.к. речь идет именно об tx amount (а не о fee) - то мне кажется корректнее использовать rounding down, а не rounding up - чтобы итоговое значение точно было меньше или равно amount, а не больше или равно.

При больше или равно в теории есть вероятность что транзакция не уйдет, т.к. в ней будет amount больше баланса.

