### PR TITLE
IOS-5474 Support for CW20 transactions

### DIFF
--- a/BlockchainSdk/WalletManagers/Cosmos/CosmosChain.swift
+++ b/BlockchainSdk/WalletManagers/Cosmos/CosmosChain.swift
@@ -179,14 +179,36 @@ extension CosmosChain {
         }
     }
     
-    var tokenDenominationByContractAddress: [String: String] {
+    func tokenDenomination(contractAddress: String, tokenCurrencySymbol: String) -> String? {
         switch self {
         case .terraV1:
-            return [
-                "uusd": "uusd",
-            ]
-        case .cosmos, .gaia, .terraV2:
-            return [:]
+            switch contractAddress {
+            case "uusd":
+                return "uusd"
+            default:
+                return nil
+            }
+        case .terraV2:
+            return tokenCurrencySymbol
+        case .cosmos, .gaia:
+            return nil
+        }
+    }
+    
+    
+    func tokenFeeDenomination(contractAddress: String, tokenCurrencySymbol: String) -> String? {
+        switch self {
+        case .terraV1:
+            switch contractAddress {
+            case "uusd":
+                return "uusd"
+            default:
+                return nil
+            }
+        case .terraV2:
+            return smallestDenomination
+        case .cosmos, .gaia:
+            return nil
         }
     }
     

--- a/BlockchainSdk/WalletManagers/Cosmos/CosmosChain.swift
+++ b/BlockchainSdk/WalletManagers/Cosmos/CosmosChain.swift
@@ -179,6 +179,15 @@ extension CosmosChain {
         }
     }
     
+    var allowCW20Tokens: Bool {
+        switch self {
+        case .terraV2:
+            return true
+        case .cosmos, .terraV1, .gaia:
+            return false
+        }
+    }
+    
     func tokenDenomination(contractAddress: String, tokenCurrencySymbol: String) -> String? {
         switch self {
         case .terraV1:

--- a/BlockchainSdk/WalletManagers/Cosmos/CosmosModels.swift
+++ b/BlockchainSdk/WalletManagers/Cosmos/CosmosModels.swift
@@ -34,6 +34,30 @@ extension CosmosBalanceResponse {
     }
 }
 
+// MARK: - Cosmos WASM smart contract interaction
+
+struct CosmosCW20BalanceRequest: Encodable {
+    private let balance: CosmosCW20BalanceAddress
+    
+    init(address: String) {
+        self.balance = CosmosCW20BalanceAddress(address: address)
+    }
+}
+
+private extension CosmosCW20BalanceRequest {
+    struct CosmosCW20BalanceAddress: Encodable {
+        let address: String
+    }
+}
+
+struct CosmosCW20QueryResult<D: Decodable>: Decodable {
+    let data: D
+}
+
+struct CosmosCW20QueryBalanceData: Decodable {
+    let balance: String
+}
+
 // MARK: - Simulate
 
 struct CosmosSimulateResponse: Decodable {

--- a/BlockchainSdk/WalletManagers/Cosmos/CosmosNetworkService.swift
+++ b/BlockchainSdk/WalletManagers/Cosmos/CosmosNetworkService.swift
@@ -47,7 +47,7 @@ class CosmosNetworkService: MultiNetworkProvider {
                     let amount = Amount(with: self.cosmosChain.blockchain, value: rawAmount)
                     
                     let tokenAmounts: [Token: Decimal] = Dictionary(try tokens.compactMap {
-                        guard let denomination = self.cosmosChain.tokenDenominationByContractAddress[$0.contractAddress] else {
+                        guard let denomination = self.cosmosChain.tokenDenomination(contractAddress: $0.contractAddress, tokenCurrencySymbol: $0.symbol) else {
                             return nil
                         }
                         

--- a/BlockchainSdk/WalletManagers/Cosmos/CosmosNetworkService.swift
+++ b/BlockchainSdk/WalletManagers/Cosmos/CosmosNetworkService.swift
@@ -21,10 +21,17 @@ class CosmosNetworkService: MultiNetworkProvider {
     }
     
     func accountInfo(for address: String, tokens: [Token], transactionHashes: [String]) -> AnyPublisher<CosmosAccountInfo, Error> {
-        providerPublisher {
+        let cw20Tokens: [Token]
+        if cosmosChain.allowCW20Tokens {
+            cw20Tokens = tokens
+        } else {
+            cw20Tokens = []
+        }
+        
+        return providerPublisher {
             $0.accounts(address: address)
-                .zip($0.balances(address: address), self.confirmedTransactionHashes(transactionHashes, with: $0))
-                .tryMap { [weak self] (accountInfo, balanceInfo, confirmedTransactionHashes) in
+                .zip($0.balances(address: address), self.cw20TokenBalances(walletAddress: address, tokens: cw20Tokens), self.confirmedTransactionHashes(transactionHashes, with: $0))
+                .tryMap { [weak self] (accountInfo, balanceInfo, cw20TokenBalances, confirmedTransactionHashes) in
                     guard
                         let self,
                         let sequenceNumber = UInt64(accountInfo?.account.sequence ?? "0")
@@ -46,17 +53,22 @@ class CosmosNetworkService: MultiNetworkProvider {
                     )
                     let amount = Amount(with: self.cosmosChain.blockchain, value: rawAmount)
                     
-                    let tokenAmounts: [Token: Decimal] = Dictionary(try tokens.compactMap {
-                        guard let denomination = self.cosmosChain.tokenDenomination(contractAddress: $0.contractAddress, tokenCurrencySymbol: $0.symbol) else {
-                            return nil
-                        }
-                        
-                        let balance = try self.parseBalance(balanceInfo, denomination: denomination, decimalValue: $0.decimalValue)
-                        return ($0, balance)
-                    }, uniquingKeysWith: {
-                        pair1, _ in
-                        pair1
-                    })
+                    let tokenAmounts: [Token: Decimal]
+                    if cosmosChain.allowCW20Tokens {
+                        tokenAmounts = cw20TokenBalances
+                    } else {
+                        tokenAmounts = Dictionary(try tokens.compactMap {
+                            guard let denomination = self.cosmosChain.tokenDenomination(contractAddress: $0.contractAddress, tokenCurrencySymbol: $0.symbol) else {
+                                return nil
+                            }
+                            
+                            let balance = try self.parseBalance(balanceInfo, denomination: denomination, decimalValue: $0.decimalValue)
+                            return ($0, balance)
+                        }, uniquingKeysWith: {
+                            pair1, _ in
+                            pair1
+                        })
+                    }
                     
                     return CosmosAccountInfo(
                         accountNumber: accountNumber,
@@ -95,6 +107,46 @@ class CosmosNetworkService: MultiNetworkProvider {
                     }
                     
                     return txResponse.txhash
+                }
+                .eraseToAnyPublisher()
+        }
+    }
+    
+    private func cw20TokenBalances(walletAddress: String, tokens: [Token]) -> AnyPublisher<[Token: Decimal], Error> {
+        tokens
+            .publisher
+            .setFailureType(to: Error.self)
+            .flatMap { [weak self] token -> AnyPublisher<(Token, Decimal), Error> in
+                guard let self = self else {
+                    return .anyFail(error: WalletError.empty)
+                }
+              
+                return self.cw20TokenBalance(walletAddress: walletAddress, token: token)
+            }
+            .collect()
+            .map {
+                Dictionary($0) { pair1, _ in pair1 }
+            }
+            .eraseToAnyPublisher()
+    }
+    
+    private func cw20TokenBalance(walletAddress: String, token: Token) -> AnyPublisher<(Token, Decimal), Error> {
+        let request = CosmosCW20BalanceRequest(address: walletAddress)
+        guard let query = try? JSONEncoder().encode(request) else {
+            return .anyFail(error: WalletError.failedToParseNetworkResponse)
+        }
+        
+        return providerPublisher {
+            $0.querySmartContract(contractAddress: token.contractAddress, query: query)
+                .tryMap { 
+                    (result: CosmosCW20QueryResult<CosmosCW20QueryBalanceData>) -> (Token, Decimal) in
+                    
+                    guard let balanceInSmallestDenomination = Decimal(string: result.data.balance) else {
+                        throw WalletError.failedToParseNetworkResponse
+                    }
+                    
+                    let balance = balanceInSmallestDenomination / token.decimalValue
+                    return (token, balance)
                 }
                 .eraseToAnyPublisher()
         }

--- a/BlockchainSdk/WalletManagers/Cosmos/CosmosRestProvider.swift
+++ b/BlockchainSdk/WalletManagers/Cosmos/CosmosRestProvider.swift
@@ -36,6 +36,10 @@ class CosmosRestProvider: HostProvider {
             .eraseToAnyPublisher()
     }
     
+    func querySmartContract<D: Decodable>(contractAddress: String, query: Data) -> AnyPublisher<CosmosCW20QueryResult<D>, Error> {
+        requestPublisher(for: .querySmartContract(contractAddress: contractAddress, query: query))
+    }
+    
     func balances(address: String) -> AnyPublisher<CosmosBalanceResponse, Error> {
         requestPublisher(for: .balances(address: address))
     }

--- a/BlockchainSdk/WalletManagers/Cosmos/CosmosTarget.swift
+++ b/BlockchainSdk/WalletManagers/Cosmos/CosmosTarget.swift
@@ -18,6 +18,7 @@ extension CosmosTarget {
     enum CosmosTargetType {
         case accounts(address: String)
         case balances(address: String)
+        case querySmartContract(contractAddress: String, query: Data)
         case simulate(data: Data)
         case txs(data: Data)
         case transactionStatus(hash: String)
@@ -31,6 +32,8 @@ extension CosmosTarget: TargetType {
             return "/cosmos/auth/v1beta1/accounts/\(address)"
         case .balances(let address):
             return "/cosmos/bank/v1beta1/balances/\(address)"
+        case .querySmartContract(let contractAddress, let query):
+            return "/cosmwasm/wasm/v1/contract/\(contractAddress)/smart/\(query.base64EncodedString())"
         case .simulate:
             return "/cosmos/tx/v1beta1/simulate"
         case .txs:
@@ -42,7 +45,7 @@ extension CosmosTarget: TargetType {
     
     var method: Moya.Method {
         switch type {
-        case .accounts, .balances, .transactionStatus:
+        case .accounts, .balances, .transactionStatus, .querySmartContract:
             return .get
         case .simulate, .txs:
             return .post
@@ -51,7 +54,7 @@ extension CosmosTarget: TargetType {
     
     var task: Moya.Task {
         switch type {
-        case .accounts, .balances, .transactionStatus:
+        case .accounts, .balances, .transactionStatus, .querySmartContract:
             return .requestPlain
         case .simulate(let data), .txs(let data):
             return .requestData(data)


### PR DESCRIPTION
Надо добавить поддержку для токенов стандарта CW20 в терре (пример — ASTRO https://terrasco.pe/mainnet/address/terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26)

**Баланс**
Чтобы получить баланс CW20 токена надо отправить запрос вида

```
https://phoenix-lcd.terra.dev/cosmwasm/wasm/v1/contract/$contract_address/smart/$query
```

где $contract_address — адрес контракта,
$query — base64 представление запроса

Запрос — это JSON вида

```
{
    "balance": {
        "address": "$wallet_address"
    }
}
```

Пример:
```
https://phoenix-lcd.terra.dev/cosmwasm/wasm/v1/contract/terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26/smart/ewogICAgImJhbGFuY2UiOiB7CiAgICAgICAgImFkZHJlc3MiOiAidGVycmExNmdnNzZxY3B4Y2tmdms4N2RjZmNzczJzanRjNWd4NDIycnBlaDgiCiAgICB9Cn0=
```

**Транзакции**

Чтобы отправить транзакцию надо использовать WalletCore-сообщение `CosmosMessage.WasmExecuteContractTransfer`:

```
let tokenMessage = CosmosMessage.WasmExecuteContractTransfer.with {
    $0.senderAddress = transaction.sourceAddress
    $0.recipientAddress = transaction.destinationAddress
    $0.contractAddress = token.contractAddress
    $0.amount = amountBytes
}

let message: CosmosMessage = CosmosMessage.with {
    $0.wasmExecuteContractTransferMessage = tokenMessage
}
```

Комиссия при этом должна быть в валюте сети (LUNA). Если попытаться запихнуть в транзакцию комиссию в токене, получим сообщение
```
{
    "tx_response": {
        "height": "0",
        "txhash": "B07F878BE1E42CD8CE8CAE45C5859523E093FC28729B36463413DE069AFF9D1E",
        "codespace": "sdk",
        "code": 13,
        "data": "",
        "raw_log": "insufficient fees; got: 100ASTRO required: 3239uluna: insufficient fee",
        "logs": [],
        "info": "",
        "gas_wanted": "0",
        "gas_used": "0",
        "tx": null,
        "timestamp": "",
        "events": []
    }
}
```