### PR TITLE
IOS-5922 Fix algo explorer link

### DIFF
--- a/BlockchainSdk/ExternalLinkProvider/AlgorandExternalLinkProvider.swift
+++ b/BlockchainSdk/ExternalLinkProvider/AlgorandExternalLinkProvider.swift
@@ -17,9 +17,9 @@ struct AlgorandExternalLinkProvider: ExternalLinkProvider {
     
     private var baseExplorerHost: String {
         if isTestnet {
-            return "testnet.algoexplorer.io"
+            return "explorer.bitquery.io/algorand_testnet"
         } else {
-            return "algoexplorer.io"
+            return "explorer.bitquery.io/algorand"
         }
     }
 


### PR DESCRIPTION
algoexplorer.io вывели из поддержки заменил, сделал как Андроид выставил

_https://explorer.bitquery.io/algorand/_