### PR TITLE
IOS-5975 Rename arbitrum to arbitrum one

### DIFF
--- a/BlockchainSdk/Common/Blockchain.swift
+++ b/BlockchainSdk/Common/Blockchain.swift
@@ -352,6 +352,8 @@ public indirect enum Blockchain: Equatable, Hashable {
             return "Shibarium" + testnetSuffix
         case .aptos:
             return "Aptos"
+        case .arbitrum:
+            return "Arbitrum One" + testnetSuffix
         default:
             var name = "\(self)".capitalizingFirstLetter()
             if let index = name.firstIndex(of: "(") {


### PR DESCRIPTION
Переименовываем в Arbitrum One.