### PR TITLE
IOS-6159 Use custom decimal coverter instead of coverting to UInt64

### DIFF
--- a/BlockchainSdk/Blockchains/Ethereum/EthereumWalletManager.swift
+++ b/BlockchainSdk/Blockchains/Ethereum/EthereumWalletManager.swift
@@ -134,7 +134,7 @@ private extension EthereumWalletManager {
                     // TODO: Fix integer overflow. Think about BigInt
                     // https://tangem.atlassian.net/browse/IOS-4268
                     // https://tangem.atlassian.net/browse/IOS-5119
-                    let fee = Decimal(UInt64(feeValue)) / decimalValue
+                    let fee = (feeValue.decimal ?? Decimal(UInt64(feeValue))) / decimalValue
 
                     let amount = Amount(with: blockchain, value: fee)
                     let parameters = EthereumFeeParameters(gasLimit: gasLimit, gasPrice: gasPrice)


### PR DESCRIPTION
При использовании кастомного конвертера из BigUInt+ в описанном кейсе не крашит. Лучшего решения не придумал, скорее всего надо будет править в скоупе рефакторинга BigDecimal