### PR TITLE
IOS-6245: Add workaround for incorrect tx history page count for some old Tron addresses

### DIFF
--- a/BlockchainSdk/Common/TransactionHistory/Tron/TronTransactionHistoryProvider.swift
+++ b/BlockchainSdk/Common/TransactionHistory/Tron/TronTransactionHistoryProvider.swift
@@ -77,8 +77,8 @@ extension TronTransactionHistoryProvider: TransactionHistoryProvider {
             // Again, Tron Blockbook is a really terrible API
             if let receivedPageNumber = response.page, receivedPageNumber < requestedPageNumber {
                 let fixedResponse = BlockBookAddressResponse(
-                    page: receivedPageNumber,
-                    totalPages: receivedPageNumber,
+                    page: requestedPageNumber,
+                    totalPages: response.totalPages,
                     itemsOnPage: response.itemsOnPage,
                     address: response.address,
                     balance: response.balance,


### PR DESCRIPTION
[IOS-6245](https://tangem.atlassian.net/browse/IOS-6245)

[IOS-6245]: https://tangem.atlassian.net/browse/IOS-6245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ