### PR TITLE
IOS-6644: Polygon history tx type mapping

### DIFF
--- a/BlockchainSdk/Blockchains/Solana/SolanaWalletManager.swift
+++ b/BlockchainSdk/Blockchains/Solana/SolanaWalletManager.swift
@@ -132,10 +132,8 @@ extension SolanaWalletManager: TransactionSender {
         let decimalAmount = transaction.amount.value * token.decimalValue
         let intAmount = (decimalAmount.rounded() as NSDecimalNumber).uint64Value
         let signer = SolanaTransactionSigner(transactionSigner: signer, walletPublicKey: wallet.publicKey)
-        
         let tokenProgramIdPublisher = networkService.tokenProgramId(contractAddress: token.contractAddress)
-        let accountExistsPublisher = accountExists(destination: transaction.destinationAddress, amountType: transaction.amount.type)
-        
+
         return tokenProgramIdPublisher
             .flatMap { [weak self] tokenProgramId -> AnyPublisher<TransactionID, Error> in
                 guard let self else {
@@ -230,7 +228,7 @@ private extension SolanaWalletManager {
                     }
                 }
                 .eraseToAnyPublisher()
-        case .token(let token):
+        case .token:
             return .justWithError(output: 0)
         case .reserve:
             return .anyFail(error: BlockchainSdkError.failedToLoadFee)

--- a/BlockchainSdk/Common/TransactionHistory/Polygon/PolygonTransactionHistoryMapper.swift
+++ b/BlockchainSdk/Common/TransactionHistory/Polygon/PolygonTransactionHistoryMapper.swift
@@ -74,14 +74,17 @@ final class PolygonTransactionHistoryMapper {
         amountType: Amount.AmountType
     ) -> TransactionRecord.TransactionType {
         switch amountType {
-        case .coin, .token where transaction.isContractInteraction:
+        case .coin where transaction.isContractInteraction,
+             .token where transaction.isContractInteraction:
             let methodName = transaction.functionName?.components(separatedBy: Constants.methodNameSeparator).first?.nilIfEmpty
             if let methodName {
                 return .contractMethodName(name: methodName)
             }
             // If the method name is absent in API - we fallback to the plain transfer
             return .transfer
-        case .coin, .token, .reserve:
+        case .coin, 
+             .token,
+             .reserve:
             // All other transactions are considered simple & plain transfers
             return .transfer
         }

--- a/BlockchainSdk/Extensions/Result+.swift
+++ b/BlockchainSdk/Extensions/Result+.swift
@@ -13,14 +13,14 @@ extension Result {
         switch self {
         case .success(let success):
             return success
-        case .failure(let failure):
+        case .failure:
             return nil
         }
     }
 
     var error: Failure? {
         switch self {
-        case .success(let success):
+        case .success:
             return nil
         case .failure(let failure):
             return failure


### PR DESCRIPTION
[IOS-6644](https://tangem.atlassian.net/browse/IOS-6644)

Была проблема с условием `case .coin, .token where transaction.isContractInteraction:`

>'where' only applies to the second pattern match in this case

Но компилятор почему-то показывал этот ворнинг только при сборке BSDK, при сборке в приле его не было - потому и не заметил

[IOS-6644]: https://tangem.atlassian.net/browse/IOS-6644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ