### PR TITLE
IOS-6698 Make changes for parse service

### DIFF
--- a/BlockchainSdk.xcodeproj/project.pbxproj
+++ b/BlockchainSdk.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		2DDEFBE82B59B44700885675 /* AlgorandProviderTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDEFBDC2B59B44700885675 /* AlgorandProviderTarget.swift */; };
 		2DDEFBFA2B5E951400885675 /* AlgorandResponse+TransactionHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDEFBF92B5E951400885675 /* AlgorandResponse+TransactionHistory.swift */; };
 		2DF7621D2B7AB92300666B74 /* AptosFeeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF7621C2B7AB92300666B74 /* AptosFeeInfo.swift */; };
+		2DFD3AA42BE560BD00FCA7DC /* TronUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DFD3AA32BE560BD00FCA7DC /* TronUtils.swift */; };
 		47420109BD3DE47300C6F23F /* Pods_BlockchainSdkTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D1A207847B605E0517D9A55F /* Pods_BlockchainSdkTests.framework */; };
 		592E206C6981F567C2FB1FDC /* Pods_BlockchainSdkExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B236300074DC3321FAA6A10D /* Pods_BlockchainSdkExample.framework */; };
 		5D006ACD239950F9008BA04D /* Wallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D006ACC239950F9008BA04D /* Wallet.swift */; };
@@ -955,6 +956,7 @@
 		2DDEFBDC2B59B44700885675 /* AlgorandProviderTarget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlgorandProviderTarget.swift; sourceTree = "<group>"; };
 		2DDEFBF92B5E951400885675 /* AlgorandResponse+TransactionHistory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AlgorandResponse+TransactionHistory.swift"; sourceTree = "<group>"; };
 		2DF7621C2B7AB92300666B74 /* AptosFeeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AptosFeeInfo.swift; sourceTree = "<group>"; };
+		2DFD3AA32BE560BD00FCA7DC /* TronUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TronUtils.swift; sourceTree = "<group>"; };
 		3452E77A600B278568F13FA9 /* Pods-BlockchainSdkExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BlockchainSdkExample.release.xcconfig"; path = "Target Support Files/Pods-BlockchainSdkExample/Pods-BlockchainSdkExample.release.xcconfig"; sourceTree = "<group>"; };
 		556382E16FB9B2894A77374E /* Pods-BlockchainSdkExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BlockchainSdkExample.debug.xcconfig"; path = "Target Support Files/Pods-BlockchainSdkExample/Pods-BlockchainSdkExample.debug.xcconfig"; sourceTree = "<group>"; };
 		5D006ACC239950F9008BA04D /* Wallet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Wallet.swift; sourceTree = "<group>"; };
@@ -3242,6 +3244,7 @@
 				DA9F76EE27EC9BCD00F0665C /* TronNetworkService.swift */,
 				DA9F76F427EC9CB400F0665C /* TronTarget.swift */,
 				DA3081312817EC1A00DE41F1 /* TronTransactionBuilder.swift */,
+				2DFD3AA32BE560BD00FCA7DC /* TronUtils.swift */,
 				2DDE5B9C29C4F8D200A5B708 /* TronWalletAssembly.swift */,
 				DA9F76EB27EC9A2900F0665C /* TronWalletManager.swift */,
 				DA3081222817AEB800DE41F1 /* protobuf */,
@@ -4796,6 +4799,7 @@
 				DC5E65372B1655CD00E81AA5 /* BitcoinScriptChunk.swift in Sources */,
 				B04E556B265FB89400679EAF /* URL+.swift in Sources */,
 				EFEADBDE2A4D737F00744407 /* SignatureInfo.swift in Sources */,
+				2DFD3AA42BE560BD00FCA7DC /* TronUtils.swift in Sources */,
 				EF3B19202AA85C230084AA1C /* DucatusExternalLinkProvider.swift in Sources */,
 				EF2D9D9E2BC3F6770055C485 /* EthereumJsonRpcProvider.swift in Sources */,
 				5D84550E243DE9B40072155E /* CardanoWalletManager.swift in Sources */,

--- a/BlockchainSdk/Blockchains/Tron/TronNetworkService.swift
+++ b/BlockchainSdk/Blockchains/Tron/TronNetworkService.swift
@@ -154,7 +154,9 @@ class TronNetworkService: MultiNetworkProvider {
                         throw WalletError.failedToParseNetworkResponse
                     }
                     
-                    let bigIntValue = BigUInt(Data(hex: hexValue))
+                    // Need use 32 byte for obtain right value
+                    let substringHexSizeValue = String(hexValue.prefix(64))
+                    let bigIntValue = BigUInt(Data(hex: substringHexSizeValue))
                     
                     let formatted = EthereumUtils.formatToPrecision(
                         bigIntValue,
@@ -164,7 +166,7 @@ class TronNetworkService: MultiNetworkProvider {
                         fallbackToScientific: false
                     )
                     
-                    guard let decimalValue = Decimal(formatted) else {
+                    guard let decimalValue = Decimal(stringValue: formatted) else {
                         throw WalletError.failedToParseNetworkResponse
                     }
                     

--- a/BlockchainSdk/Blockchains/Tron/TronUtils.swift
+++ b/BlockchainSdk/Blockchains/Tron/TronUtils.swift
@@ -1,0 +1,24 @@
+//
+//  TronUtils.swift
+//  BlockchainSdk
+//
+//  Created by skibinalexander on 03.05.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import BigInt
+
+struct TronUtils {
+    func combineBigUIntValueAtBalance(response constantResult: [String]) throws -> BigUInt {
+        guard let hexValue = constantResult.first else {
+            throw WalletError.failedToParseNetworkResponse
+        }
+        
+        // Need use 32 byte for obtain right value
+        let substringHexSizeValue = String(hexValue.prefix(64))
+        let bigIntValue = BigUInt(Data(hex: substringHexSizeValue))
+        
+        return bigIntValue
+    }
+}

--- a/BlockchainSdkTests/Tron/TronTests.swift
+++ b/BlockchainSdkTests/Tron/TronTests.swift
@@ -104,4 +104,15 @@ class TronTests: XCTestCase {
         
         XCTAssertEqual(transactionDataList, expectedTransactionDataList)
     }
+    
+    func testBalanceResponse() throws {
+        let longConstantResult = "0000000000000000000000000000000000000000000000001e755ae3061df48700000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        
+        let shortConstantResult = "0000000000000000000000000000000000000000000000000000000001e835f8"
+        
+        let utils = TronUtils()
+        
+        try XCTAssertEqual(utils.combineBigUIntValueAtBalance(response: [longConstantResult]), "2194760324519687303")
+        try XCTAssertEqual(utils.combineBigUIntValueAtBalance(response: [shortConstantResult]), "31995384")
+    }
 }


### PR DESCRIPTION
Есть вот такой пользак, у него какой то ноунейм токен в объеме 21,947,603,245.196873. В эксплорере отображается нормально, но через апишку приходит:hex: "0000000000000000000000000000000000000000000000001e755ae3061df48700000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"

uint:29426924883418451253916428598539609765612934244540632973082060873440904514738313537826234638470035192393060778841382353758278755271914087710641947252658366028627578441433088

Решение:
Обсудили с @dbaturin  что нужно резать до первый 32 байт остальное отбрасывать.