### PR TITLE
IOS-6830 Updated the way x-addresses are handled

### DIFF
--- a/BlockchainSdk/Blockchains/XRP/XRPAddressService.swift
+++ b/BlockchainSdk/Blockchains/XRP/XRPAddressService.swift
@@ -60,9 +60,9 @@ extension XRPAddressService: AddressValidator {
 }
 
 @available(iOS 13.0, *)
-extension XRPAddressService: AddressAdditionalFieldParser {
-    public func hasAdditionalField(_ address: String) -> Bool {
+extension XRPAddressService: AddressAdditionalFieldService {
+    public func canEmbedAdditionalField(into address: String) -> Bool {
         let xAddress = try? XRPAddress(xAddress: address)
-        return xAddress?.tag != nil
+        return xAddress == nil
     }
 }

--- a/BlockchainSdk/Common/Address/AddressService.swift
+++ b/BlockchainSdk/Common/Address/AddressService.swift
@@ -18,8 +18,8 @@ public protocol AddressProvider {
     func makeAddress(for publicKey: Wallet.PublicKey, with addressType: AddressType) throws -> Address
 }
 
-public protocol AddressAdditionalFieldParser {
-    func hasAdditionalField(_ address: String) -> Bool
+public protocol AddressAdditionalFieldService {
+    func canEmbedAdditionalField(into address: String) -> Bool
 }
 
 // A convenient extension for using a raw public key


### PR DESCRIPTION
Теперь трактуем отсутствие тега в х-адресе как повод для блокировки поля ввода тега