### PR TITLE
IOS-7058: Remove trailing slash for some public API

### DIFF
--- a/BlockchainSdk.xcodeproj/project.pbxproj
+++ b/BlockchainSdk.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		B00DF99C2BBEAB7B004397CB /* GetBlockAPIResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00DF99B2BBEAB7B004397CB /* GetBlockAPIResolver.swift */; };
 		B00DF99E2BBEAB91004397CB /* InfuraAPIResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00DF99D2BBEAB91004397CB /* InfuraAPIResolver.swift */; };
 		B00DF9A02BBEACA2004397CB /* QuickNodeAPIResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00DF99F2BBEACA2004397CB /* QuickNodeAPIResolver.swift */; };
+		B016CC542C13479E0025ADC3 /* PublicAPIResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B016CC532C13479E0025ADC3 /* PublicAPIResolver.swift */; };
 		B0201F462BCE95C000AA0807 /* NowNodesAPIKeysInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0201F452BCE95C000AA0807 /* NowNodesAPIKeysInfoProvider.swift */; };
 		B044B3A126047F5500D9864F /* RosettaResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B044B3A026047F5500D9864F /* RosettaResponse.swift */; };
 		B04DC62725AC1C50009AA7B3 /* JSONDecoder+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04DC62625AC1C50009AA7B3 /* JSONDecoder+.swift */; };
@@ -1119,6 +1120,7 @@
 		B00DF99B2BBEAB7B004397CB /* GetBlockAPIResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBlockAPIResolver.swift; sourceTree = "<group>"; };
 		B00DF99D2BBEAB91004397CB /* InfuraAPIResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfuraAPIResolver.swift; sourceTree = "<group>"; };
 		B00DF99F2BBEACA2004397CB /* QuickNodeAPIResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickNodeAPIResolver.swift; sourceTree = "<group>"; };
+		B016CC532C13479E0025ADC3 /* PublicAPIResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicAPIResolver.swift; sourceTree = "<group>"; };
 		B0201F452BCE95C000AA0807 /* NowNodesAPIKeysInfoProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowNodesAPIKeysInfoProvider.swift; sourceTree = "<group>"; };
 		B022D30D2537292800D934D7 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B022D3102537475B00D934D7 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -2604,6 +2606,7 @@
 		B00DF9942BBEAABC004397CB /* APIResolvers */ = {
 			isa = PBXGroup;
 			children = (
+				B016CC522C1347930025ADC3 /* Public */,
 				B0201F472BCE95D500AA0807 /* GetBlock */,
 				B0201F442BCE95AD00AA0807 /* NowNodes */,
 				B00DF9902BBEA9DA004397CB /* APIModels.swift */,
@@ -2614,6 +2617,14 @@
 				B00B58C32BCEB917007475F7 /* APIKeysInfoProvider.swift */,
 			);
 			path = APIResolvers;
+			sourceTree = "<group>";
+		};
+		B016CC522C1347930025ADC3 /* Public */ = {
+			isa = PBXGroup;
+			children = (
+				B016CC532C13479E0025ADC3 /* PublicAPIResolver.swift */,
+			);
+			path = Public;
 			sourceTree = "<group>";
 		};
 		B0201F442BCE95AD00AA0807 /* NowNodes */ = {
@@ -4225,6 +4236,7 @@
 				2DDE5BA329C4F8D200A5B708 /* TezosWalletAssembly.swift in Sources */,
 				DA18C4A9297AC63600EC4C05 /* NowNodesBlockBookConfig.swift in Sources */,
 				5D0EEE67253EF2E800758FDC /* TezosTransactionBuilder.swift in Sources */,
+				B016CC542C13479E0025ADC3 /* PublicAPIResolver.swift in Sources */,
 				5D4B33C023F6EA6C00C93A84 /* BlockchairNetworkProvider.swift in Sources */,
 				5DC7DD64244077E4008F83F2 /* XRPTransactionBuilder.swift in Sources */,
 				EF666C202A288AEF0044986F /* AdaliteTokenDTO.swift in Sources */,

--- a/BlockchainSdk/Blockchains/Kaspa/Network/KaspaTarget.swift
+++ b/BlockchainSdk/Blockchains/Kaspa/Network/KaspaTarget.swift
@@ -16,15 +16,15 @@ struct KaspaTarget: TargetType {
     var path: String {
         switch request {
         case .blueScore:
-            return "/info/virtual-chain-blue-score"
+            return "info/virtual-chain-blue-score"
         case .balance(let address):
-            return "/addresses/\(address)/balance"
+            return "addresses/\(address)/balance"
         case .utxos(let address):
-            return "/addresses/\(address)/utxos"
+            return "addresses/\(address)/utxos"
         case .transactions:
-            return "/transactions"
+            return "transactions"
         case .transaction(let hash):
-            return "/transactions/\(hash)"
+            return "transactions/\(hash)"
         }
     }
     

--- a/BlockchainSdk/Common/API/APIResolvers/APINodeInfoResolver.swift
+++ b/BlockchainSdk/Common/API/APIResolvers/APINodeInfoResolver.swift
@@ -15,11 +15,8 @@ struct APINodeInfoResolver {
     func resolve(for providerType: NetworkProviderType) -> NodeInfo? {
         switch providerType {
         case .public(let link):
-            guard let url = URL(string: link) else {
-                return nil
-            }
-
-            return .init(url: url)
+            return PublicAPIResolver(blockchain: blockchain)
+                .resolve(for: link)
         case .nowNodes:
             return NowNodesAPIResolver(apiKey: config.nowNodesApiKey)
                 .resolve(for: blockchain)

--- a/BlockchainSdk/Common/API/APIResolvers/Public/PublicAPIResolver.swift
+++ b/BlockchainSdk/Common/API/APIResolvers/Public/PublicAPIResolver.swift
@@ -1,0 +1,44 @@
+//
+//  PublicAPIResolver.swift
+//  BlockchainSdk
+//
+//  Created by Andrew Son on 07/06/24.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+struct PublicAPIResolver {
+    let blockchain: Blockchain
+
+    func resolve(for link: String) -> NodeInfo? {
+        var linkForURL: String = link
+
+        // We need to remove trailing slash from stellar, because StellarSDK manually adds it
+        // when creates request link
+        if case .stellar = blockchain {
+            linkForURL = removeTrailingSlash(from: linkForURL)
+        }
+
+        // We also need to remove trailing slash for EVM, because some JSON RPC nodes didn't work correctly
+        // if link has trailing slash
+        if blockchain.isEvm {
+            linkForURL = removeTrailingSlash(from: linkForURL)
+        }
+
+        guard let url = URL(string: linkForURL) else {
+            return nil
+        }
+
+        return NodeInfo(url: url)
+    }
+
+    private func removeTrailingSlash(from link: String) -> String {
+        var clearedLink = link
+        if clearedLink.hasSuffix("/") {
+            clearedLink.removeLast()
+        }
+
+        return clearedLink
+    }
+}


### PR DESCRIPTION
* Удаляем слэши для всех EVM сетей, т.к. некоторые апишки не работают адекватно, перестают отвечать
* удаляем для стеллара, т.к. либа сама добавляет слэш, при создании запроа
* Приводим к общему виду каспу, слэш будет в самой ссылке