### PR TITLE
IOS-7185 Fix switched api for radiant

### DIFF
--- a/BlockchainSdk/Common/WebSocket/WebSocketConnection.swift
+++ b/BlockchainSdk/Common/WebSocket/WebSocketConnection.swift
@@ -13,7 +13,7 @@ actor WebSocketConnection {
     private let ping: Ping
     private let timeout: TimeInterval
     
-    private var _sessionWebSocketTask: Task<URLSessionWebSocketTaskWrapper, Never>?
+    private var _sessionWebSocketTask: Task<URLSessionWebSocketTaskWrapper, any Error>?
     private var pingTask: Task<Void, Error>?
     private var timeoutTask: Task<Void, Error>?
 
@@ -28,7 +28,7 @@ actor WebSocketConnection {
     }
     
     public func send(_ message: URLSessionWebSocketTask.Message) async throws {
-        let webSocketTask = await setupWebSocketTask()
+        let webSocketTask = try await setupWebSocketTask()
         log("Send: \(message)")
 
         // Send a message
@@ -40,7 +40,7 @@ actor WebSocketConnection {
     }
 
     public func receive() async throws -> Data {
-        guard let webSocket = await _sessionWebSocketTask?.value else {
+        guard let webSocket = try await _sessionWebSocketTask?.value else {
             throw WebSocketConnectionError.webSocketNotFound
         }
         
@@ -79,7 +79,7 @@ private extension WebSocketConnection {
     }
     
     func ping() async throws {
-        guard let webSocket = await _sessionWebSocketTask?.value else {
+        guard let webSocket = try await _sessionWebSocketTask?.value else {
             throw WebSocketConnectionError.webSocketNotFound
         }
         
@@ -96,9 +96,9 @@ private extension WebSocketConnection {
         startPingTask()
     }
     
-    func setupWebSocketTask() async -> URLSessionWebSocketTaskWrapper {
+    func setupWebSocketTask() async throws -> URLSessionWebSocketTaskWrapper {
         if let _sessionWebSocketTask {
-            let socket = await _sessionWebSocketTask.value
+            let socket = try await _sessionWebSocketTask.value
             log("Return existed \(socket)")
             return socket
         }
@@ -107,14 +107,14 @@ private extension WebSocketConnection {
             let socket = URLSessionWebSocketTaskWrapper(url: url)
             
             log("\(socket) start connect")
-            await socket.connect()
+            try await socket.connect()
             log("\(socket) did open")
 
             return socket
         }
         
         _sessionWebSocketTask = connectingTask
-        return await connectingTask.value
+        return try await connectingTask.value
     }
     
     func mapToData(from message: URLSessionWebSocketTask.Message) throws -> Data {


### PR DESCRIPTION
Правка переключения electrum

🟠 16:13:13:297: Switchable publisher catched error: Error Domain=NSURLErrorDomain Code=-1003 "A server with the specified hostname could not be found." UserInfo={NSErrorFailingURLStringKey=https://electrumx-03-ssl.radiant4people.com:51002/, NSErrorFailingURLKey=https://electrumx-03-ssl.radiant4people.com:51002/, _NSURLErrorRelatedURLSessionTaskErrorKey=(
🟠 16:13:13:298: Switching to next publisher on host: wss://electrumx-01-ssl.radiant4people.com:51002/