### PR TITLE
IOS-7172 Refactoring `CardanoMinAdaAmount`

### DIFF
--- a/BlockchainSdk.xcodeproj/project.pbxproj
+++ b/BlockchainSdk.xcodeproj/project.pbxproj
@@ -787,6 +787,7 @@
 		EFB952402A6FEF1700996D16 /* TransactionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB9523F2A6FEF1700996D16 /* TransactionRecord.swift */; };
 		EFBA17FE2988623F00C23955 /* TransactionSendResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFBA17FD2988623F00C23955 /* TransactionSendResult.swift */; };
 		EFBE76912A7C066C00CD918B /* TransactionHistoryProviderFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFBE76902A7C066C00CD918B /* TransactionHistoryProviderFactory.swift */; };
+		EFC5E5132C3597CF00EC5C87 /* CardanoFeeParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC5E5122C3597CF00EC5C87 /* CardanoFeeParameters.swift */; };
 		EFCD1D192A586BEF009C8624 /* CardanoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF32FEE22A3B626E002ED43F /* CardanoTests.swift */; };
 		EFD32AE429E9B7800026353E /* RavencoinTransactionHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD32AE329E9B7800026353E /* RavencoinTransactionHistory.swift */; };
 		EFD39C9F2A6E6C700055D215 /* AddressTypesConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD39C9E2A6E6C700055D215 /* AddressTypesConfig.swift */; };
@@ -1635,6 +1636,7 @@
 		EFB9523F2A6FEF1700996D16 /* TransactionRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionRecord.swift; sourceTree = "<group>"; };
 		EFBA17FD2988623F00C23955 /* TransactionSendResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSendResult.swift; sourceTree = "<group>"; };
 		EFBE76902A7C066C00CD918B /* TransactionHistoryProviderFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistoryProviderFactory.swift; sourceTree = "<group>"; };
+		EFC5E5122C3597CF00EC5C87 /* CardanoFeeParameters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardanoFeeParameters.swift; sourceTree = "<group>"; };
 		EFD32AE329E9B7800026353E /* RavencoinTransactionHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RavencoinTransactionHistory.swift; sourceTree = "<group>"; };
 		EFD39C9E2A6E6C700055D215 /* AddressTypesConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressTypesConfig.swift; sourceTree = "<group>"; };
 		EFD717C92A25EA8500E5430D /* WalletCoreABIEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletCoreABIEncoder.swift; sourceTree = "<group>"; };
@@ -2490,6 +2492,7 @@
 				EF54FC282A8A8A0E00968C52 /* CardanoUtil.swift */,
 				2DDE5B9429C4F8D200A5B708 /* CardanoWalletAssembly.swift */,
 				5D84550D243DE9B40072155E /* CardanoWalletManager.swift */,
+				EFC5E5122C3597CF00EC5C87 /* CardanoFeeParameters.swift */,
 				5D845512243DEAAE0072155E /* Adalite */,
 				B04E8D4E25F8F65E00821CBE /* Rosetta */,
 			);
@@ -4848,6 +4851,7 @@
 				5D7D242D25136254001B9A4F /* XRPLResponse.swift in Sources */,
 				EF2BC61E29DAC649003D3F18 /* RavencoinNetworkProvider.swift in Sources */,
 				B6F89EB02BB215830009A453 /* SubscanPolkadotAccountHealthNetworkService.swift in Sources */,
+				EFC5E5132C3597CF00EC5C87 /* CardanoFeeParameters.swift in Sources */,
 				DA63B09E29CB3FC700AC6E49 /* KaspaTransaction.swift in Sources */,
 				DAED921F27A150E500F188D7 /* PolkadotAddressService.swift in Sources */,
 				EF5820412B31B54D00940387 /* EstimationFeeAddressFactory.swift in Sources */,

--- a/BlockchainSdk/Blockchains/Cardano/CardanoFeeParameters.swift
+++ b/BlockchainSdk/Blockchains/Cardano/CardanoFeeParameters.swift
@@ -1,0 +1,14 @@
+//
+//  CardanoFeeParameters.swift
+//  BlockchainSdk
+//
+//  Created by Sergey Balashov on 03.07.2024.
+//
+
+import Foundation
+
+struct CardanoFeeParameters: FeeParameters {
+    let adaValue: UInt64
+    let change: UInt64
+    let useMaxAmount: Bool
+}

--- a/BlockchainSdk/Blockchains/Cardano/CardanoTransactionBuilder.swift
+++ b/BlockchainSdk/Blockchains/Cardano/CardanoTransactionBuilder.swift
@@ -89,6 +89,9 @@ extension CardanoTransactionBuilder {
     func minChange(amount: Amount) throws -> UInt64 {
         switch amount.type {
         case .coin:
+            let hasTokens = outputs.contains { $0.assets.contains { $0.amount > 0 } }
+            assert(hasTokens, "Use this only if wallet has tokens")
+
             return try minChange(exclude: nil)
             
         case .token(let token):
@@ -263,12 +266,6 @@ private extension CardanoTransactionBuilder {
         )
     }
 
-    enum BuildCardanoSigningInputOption {
-        case useMaxAmount
-        case adaValue(UInt64)
-        case parameters(CardanoFeeParameters)
-    }
-
     func buildCardanoSigningInput(source: String, destination: String, option: BuildCardanoSigningInputOption, tokenAmount: TokenAmount?) throws -> CardanoSigningInput {
         if outputs.isEmpty {
             throw CardanoError.noUnspents
@@ -357,6 +354,12 @@ private extension CardanoTransactionBuilder {
     struct TokenAmount {
         let token: Token
         let amount: UInt64
+    }
+
+    enum BuildCardanoSigningInputOption {
+        case useMaxAmount
+        case adaValue(UInt64)
+        case parameters(CardanoFeeParameters)
     }
 }
 

--- a/BlockchainSdk/Blockchains/Cardano/CardanoTransactionBuilder.swift
+++ b/BlockchainSdk/Blockchains/Cardano/CardanoTransactionBuilder.swift
@@ -13,6 +13,8 @@ import TangemSdk
 
 // You can decode your CBOR transaction here: https://cbor.me
 class CardanoTransactionBuilder {
+    typealias FeeResult = (fee: UInt64, parameters: CardanoFeeParameters)
+
     private var outputs: [CardanoUnspentOutput] = []
     private let coinType: CoinType = .cardano
 
@@ -73,67 +75,26 @@ extension CardanoTransactionBuilder {
         return output.encoded
     }
 
-    func getFee(amount: Amount, destination: String, source: String) throws -> Decimal {
-        let inputAmountType = try inputAmountType(
-            amount: amount,
-            fee: .zeroCoin(for: .cardano(extended: false)),
-            feeCalculation: true
-        )
-
-        let input = try buildCardanoSigningInput(
-            source: source,
-            destination: destination,
-            amount: inputAmountType
-        )
-
-        return Decimal(input.plan.fee)
-    }
-
-    /// Use this method when calculating the ada value which will be sent in the transaction
-    /// Conditions:
-    /// - If the amount is `Cardano` then will return  just `amount`
-    /// - If the amount is a `token` and enough for the change then will return `minAdaValue`
-    /// - If the amount is a `token` and not enough for the change then will return `balance - fee`
-    /// - If the amount is a `token` and not enough for the minValue then will return `minAdaValue`
-    func buildCardanoSpendingAdaValue(amount: Amount, fee: Amount) throws -> UInt64 {
-        let uint64Amount = amount.value.moveRight(decimals: amount.decimals).roundedDecimalNumber.uint64Value
-
+    func getFee(amount: Amount, destination: String, source: String) throws -> FeeResult {
         switch amount.type {
         case .coin:
-            return uint64Amount
+            return try getFeeCoin(amount: amount.uint64Amount, destination: destination, source: source)
         case .token(let token):
-            let uint64Fee = fee.value.moveRight(decimals: fee.decimals).roundedDecimalNumber.uint64Value
-            let minChange = try minChange(amount: amount)
-            let spendingAdaValue = try buildMinAdaValueUInt64Amount(token: token, amount: uint64Amount, fee: uint64Fee, minChange: minChange)
-            return spendingAdaValue
+            return try getFeeToken(.init(token: token, amount: amount.uint64Amount), destination: destination, source: source)
         case .reserve:
             throw BlockchainSdkError.notImplemented
         }
     }
-    
+
     func minChange(amount: Amount) throws -> UInt64 {
         switch amount.type {
         case .coin:
-            let hasTokens = outputs.contains { $0.assets.contains { $0.amount > 0 } }
-            assert(hasTokens, "Use this only if wallet has tokens")
-
             return try minChange(exclude: nil)
             
         case .token(let token):
             let asset = try self.asset(for: token)
-            let uint64Amount = amount.value.moveRight(decimals: amount.decimals).roundedDecimalNumber.uint64Value
+            return try minChange(token: token, uint64Amount: amount.uint64Amount)
 
-            let tokenBalance: UInt64 = outputs.reduce(0) { partialResult, output in
-                let amountInOutput = output.assets
-                    .filter { $0.policyID == asset.policyID }
-                    .reduce(0) { $0 + $1.amount }
-                
-                return partialResult + amountInOutput
-            }
-            
-            let isSpendFullTokenAmount = tokenBalance == uint64Amount
-            return try minChange(exclude: isSpendFullTokenAmount ? token : nil)
-            
         case .reserve:
             throw BlockchainSdkError.notImplemented
         }
@@ -144,9 +105,87 @@ extension CardanoTransactionBuilder {
     }
 }
 
+// MARK: - Fee
+
+private extension CardanoTransactionBuilder {
+    func getFeeCoin(amount: UInt64, destination: String, source: String) throws -> FeeResult {
+        let input = try buildCardanoSigningInput(
+            source: source,
+            destination: destination,
+            option: .adaValue(amount),
+            tokenAmount: nil
+        )
+
+        let parameters = CardanoFeeParameters(
+            adaValue: input.plan.amount,
+            change: input.plan.change,
+            useMaxAmount: input.transferMessage.useMaxAmount
+        )
+
+        return (fee: input.plan.fee, parameters: parameters)
+    }
+
+    func getFeeToken(_ tokenAmount: TokenAmount, destination: String, source: String) throws -> FeeResult {
+        let uint64AdaAmount = try buildCardanoMinAdaAmount(asset: asset(for: tokenAmount.token), amount: tokenAmount.amount)
+
+        let balance = outputs.reduce(0, { $0 + $1.amount })
+        // If we'll try to build the transaction with adaValue more then balance
+        // We'll receive the error from the WalletCore
+        let adaValue = min(balance, uint64AdaAmount)
+
+        // First calculation with simple ada value
+        var input = try buildCardanoSigningInput(
+            source: source,
+            destination: destination,
+            option: .adaValue(adaValue),
+            tokenAmount: tokenAmount
+        )
+
+        let minChange = try minChange(token: tokenAmount.token, uint64Amount: tokenAmount.amount)
+
+        // If we don't have the balance for receive the minChange
+        // We'll use max amount and have to recalculate fee without the change output
+        if input.plan.change > 0, input.plan.change < minChange {
+            input = try buildCardanoSigningInput(
+                source: source,
+                destination: destination,
+                option: .useMaxAmount,
+                tokenAmount: tokenAmount
+            )
+        }
+
+        // The WalletCore can produce plan amount less than adaValue
+        // sometimes it even may be workable and the network accepts the tx
+        // But we decided that we would not allow this
+        let sendingAdaAmount = max(input.plan.amount, adaValue)
+        let parameters = CardanoFeeParameters(
+            adaValue: sendingAdaAmount,
+            change: input.plan.change,
+            useMaxAmount: input.transferMessage.useMaxAmount
+        )
+
+        return (fee: input.plan.fee, parameters: parameters)
+    }
+}
+
 // MARK: - Private
 
-extension CardanoTransactionBuilder {
+private extension CardanoTransactionBuilder {
+    func minChange(token: Token, uint64Amount: UInt64) throws -> UInt64 {
+        let asset = try self.asset(for: token)
+
+        let tokenBalance: UInt64 = outputs.reduce(0) { partialResult, output in
+            let amountInOutput = output.assets
+                .filter { $0.policyID == asset.policyID }
+                .reduce(0) { $0 + $1.amount }
+
+            return partialResult + amountInOutput
+        }
+
+        let isSpendFullTokenAmount = tokenBalance == uint64Amount
+        return try minChange(exclude: isSpendFullTokenAmount ? token : nil)
+    }
+
     /// Use this method for calculate min value for the change output
     func minChange(exclude: Token?) throws -> UInt64 {
         let assetsBalances = try assetsBalances(exclude: exclude)
@@ -172,30 +211,6 @@ extension CardanoTransactionBuilder {
             }
     }
 
-    func buildMinAdaValueUInt64Amount(token: Token, amount: UInt64, fee: UInt64, minChange: UInt64) throws -> UInt64 {
-        let asset = try self.asset(for: token)
-        let tokenBundle = CardanoTokenBundle.with {
-            $0.token = [buildCardanoTokenAmount(asset: asset, amount: BigUInt(amount))]
-        }
-        let minAmount = try CardanoMinAdaAmount(tokenBundle: tokenBundle.serializedData())
-        let adaBalance = outputs.reduce(0) { $0 + $1.amount }
-
-        // The wallet doesn't have enough balance
-        if minAmount > adaBalance {
-            return minAmount
-        }
-
-        let change = adaBalance - minAmount
-        // If the wallet doesn't have enough balance for minimum change
-        // Then spend all ADA
-        if change > 0, change < minChange {
-            let spendingAdaValue = adaBalance - fee
-            return spendingAdaValue
-        }
-
-        return minAmount
-    }
-
     func asset(for token: Token) throws -> CardanoUnspentOutput.Asset {
         let assetFilter = CardanoAssetFilter(contractAddress: token.contractAddress)
 
@@ -215,6 +230,8 @@ extension CardanoTransactionBuilder {
         return asset
     }
 
+    // MARK: - Building
+
     func buildCardanoTokenAmount(asset: CardanoUnspentOutput.Asset, amount: BigUInt) -> CardanoTokenAmount {
         CardanoTokenAmount.with {
             $0.policyID = asset.policyID
@@ -224,63 +241,46 @@ extension CardanoTransactionBuilder {
         }
     }
 
-    func inputAmountType(amount: Amount, fee: Amount, feeCalculation: Bool) throws -> InputAmountType {
-        let uint64AdaAmount = try buildCardanoSpendingAdaValue(amount: amount, fee: fee)
-
-        switch amount.type {
-        case .coin:
-            return .ada(uint64AdaAmount)
-        case .token(let token):
-            let uint64TokenAmount = amount.value.moveRight(decimals: amount.decimals).roundedDecimalNumber.uint64Value
-
-            if feeCalculation {
-                let balance = outputs.reduce(0, { $0 + $1.amount })
-                // If we'll try to build the transaction with adaValue more then balance
-                // We'll receive the error from the WalletCore
-                let adaValue = min(balance, uint64AdaAmount)
-                return .token(token: token, amount: uint64TokenAmount, adaValue: adaValue)
-            }
-
-            return .token(token: token, amount: uint64TokenAmount, adaValue: uint64AdaAmount)
-        case .reserve:
-            throw BlockchainSdkError.notImplemented
+    func buildCardanoMinAdaAmount(asset: CardanoUnspentOutput.Asset, amount: UInt64) throws-> UInt64 {
+        let tokenBundle = CardanoTokenBundle.with {
+            $0.token = [buildCardanoTokenAmount(asset: asset, amount: BigUInt(amount))]
         }
+        let minAmount = try CardanoMinAdaAmount(tokenBundle: tokenBundle.serializedData())
+
+        return minAmount
     }
 
     func buildCardanoSigningInput(transaction: Transaction) throws -> CardanoSigningInput {
-        let amount = try inputAmountType(amount: transaction.amount, fee: transaction.fee.amount, feeCalculation: false)
+        guard let parameters = transaction.fee.parameters as? CardanoFeeParameters else {
+            throw CardanoTransactionBuilderError.feeParametersNotFound
+        }
 
         return try buildCardanoSigningInput(
             source: transaction.sourceAddress,
             destination: transaction.destinationAddress,
-            amount: amount
+            option: .parameters(parameters),
+            tokenAmount: transaction.amount.tokenAmount
         )
     }
 
-    func buildCardanoSigningInput(source: String, destination: String, amount: InputAmountType) throws -> CardanoSigningInput {
-        var input = CardanoSigningInput.with {
-            $0.transferMessage.toAddress = destination
-            $0.transferMessage.changeAddress = source
-            $0.transferMessage.useMaxAmount = false
-            // Transaction validity time. Currently we are using absolute values.
-            // At 16 April 2023 was 90007700 slot number.
-            // We need to rework this logic to use relative validity time.
-            // TODO: https://tangem.atlassian.net/browse/IOS-3471
-            // This can be constructed using absolute ttl slot from `/metadata` endpoint.
-            $0.ttl = 190000000
-        }
+    enum BuildCardanoSigningInputOption {
+        case useMaxAmount
+        case adaValue(UInt64)
+        case parameters(CardanoFeeParameters)
+    }
 
+    func buildCardanoSigningInput(source: String, destination: String, option: BuildCardanoSigningInputOption, tokenAmount: TokenAmount?) throws -> CardanoSigningInput {
         if outputs.isEmpty {
             throw CardanoError.noUnspents
         }
 
-        input.utxos = outputs.map { output -> CardanoTxInput in
+        let utxos = outputs.map { output -> CardanoTxInput in
             CardanoTxInput.with {
                 $0.outPoint.txHash = Data(hexString: output.transactionHash)
                 $0.outPoint.outputIndex = output.outputIndex
                 $0.address = output.address
                 $0.amount = output.amount
-                
+
                 if !output.assets.isEmpty {
                     $0.tokenAmount = output.assets.map { asset in
                         CardanoTokenAmount.with {
@@ -294,39 +294,74 @@ extension CardanoTransactionBuilder {
             }
         }
 
-        switch amount {
-        case .ada(let uInt64):
-            // For coin just set amount which will be sent
-            input.transferMessage.amount = uInt64
-        case .token(let token, let uInt64, let adaValue):
-            let tokenBundle = try CardanoTokenBundle.with {
-                let asset = try asset(for: token)
-                $0.token = [buildCardanoTokenAmount(asset: asset, amount: BigUInt(uInt64))]
+        var input = try CardanoSigningInput.with {
+            $0.utxos = utxos
+
+            $0.transferMessage.toAddress = destination
+            $0.transferMessage.changeAddress = source
+            switch option {
+            case .useMaxAmount:
+                $0.transferMessage.useMaxAmount = true
+                // We don't set the `transferMessage.amount` here because we `useMaxAmount`
+            case .adaValue(let adaValue):
+                $0.transferMessage.useMaxAmount = false
+                $0.transferMessage.amount = adaValue
+            case .parameters(let parameters):
+                $0.transferMessage.useMaxAmount = parameters.useMaxAmount
+                $0.transferMessage.amount = parameters.adaValue
             }
 
-            // We have to set the minAmount because the utxo amount mustn't be empty
-            input.transferMessage.amount = adaValue
-            input.transferMessage.tokenAmount = tokenBundle
+            if let tokenAmount {
+                let tokenBundle = try CardanoTokenBundle.with {
+                    let asset = try asset(for: tokenAmount.token)
+                    $0.token = [buildCardanoTokenAmount(asset: asset, amount: BigUInt(tokenAmount.amount))]
+                }
+
+                $0.transferMessage.tokenAmount = tokenBundle
+            }
+
+            // Transaction validity time. Currently we are using absolute values.
+            // At 16 April 2023 was 90007700 slot number.
+            // We need to rework this logic to use relative validity time.
+            // TODO: https://tangem.atlassian.net/browse/IOS-3471
+            // This can be constructed using absolute ttl slot from `/metadata` endpoint.
+            $0.ttl = 190000000
         }
 
         input.plan = AnySigner.plan(input: input, coin: coinType)
 
         if input.plan.error != .ok {
             Log.debug("CardanoSigningInput has a error: \(input.plan.error)")
-            throw WalletError.failedToBuildTx
+            throw CardanoTransactionBuilderError.walletCoreError
         }
 
         return input
     }
 }
 
-extension CardanoTransactionBuilder {
-    enum InputAmountType {
-        case ada(UInt64)
-        case token(token: Token, amount: UInt64, adaValue: UInt64)
+private extension Amount {
+    var tokenAmount: CardanoTransactionBuilder.TokenAmount? {
+        guard case .token(let token) = type else {
+            return nil
+        }
+
+        return .init(token: token, amount: uint64Amount)
+    }
+
+    var uint64Amount: UInt64 {
+        value.moveRight(decimals: decimals).roundedDecimalNumber.uint64Value
+    }
+}
+
+private extension CardanoTransactionBuilder {
+    struct TokenAmount {
+        let token: Token
+        let amount: UInt64
     }
 }
 
 enum CardanoTransactionBuilderError: Error {
     case assetNotFound
+    case walletCoreError
+    case feeParametersNotFound
 }

--- a/BlockchainSdk/Blockchains/Cardano/CardanoWalletManager.swift
+++ b/BlockchainSdk/Blockchains/Cardano/CardanoWalletManager.swift
@@ -108,11 +108,12 @@ extension CardanoWalletManager: TransactionSender {
     
     func getFee(amount: Amount, destination: String) -> AnyPublisher<[Fee], Error> {
         do {
-            var feeValue = try transactionBuilder.getFee(amount: amount, destination: destination, source: defaultSourceAddress)
+            let (uInt64Fee, parameters) = try transactionBuilder.getFee(amount: amount, destination: destination, source: defaultSourceAddress)
+            var feeValue = Decimal(uInt64Fee)
             feeValue.round(scale: wallet.blockchain.decimalCount, roundingMode: .up)
             feeValue /= wallet.blockchain.decimalValue
             let feeAmount = Amount(with: wallet.blockchain, value: feeValue)
-            let fee = Fee(feeAmount)
+            let fee = Fee(feeAmount, parameters: parameters)
             return .justWithError(output: [fee])
         } catch {
             return .anyFail(error: error)
@@ -137,30 +138,26 @@ extension CardanoWalletManager: WithdrawalNotificationProvider {
         return nil
     }
 
-    func withdrawalNotification(amount: Amount, fee: Amount) -> WithdrawalNotification? {
+    func withdrawalNotification(amount: Amount, fee: Fee) -> WithdrawalNotification? {
         // We have to show the notification only when send the token
         guard amount.type.isToken else {
             return nil
         }
 
-        do {
-            let adaValue = try transactionBuilder.buildCardanoSpendingAdaValue(amount: amount, fee: fee)
-            let minAmountDecimal = Decimal(adaValue) / wallet.blockchain.decimalValue
-            let amount = Amount(with: wallet.blockchain, value: minAmountDecimal)
-
-            return .cardanoWillBeSendAlongToken(amount: amount)
-
-        } catch {
-            print("CardanoWalletManager", #function, "catch error: \(error)")
+        guard let parameters = fee.parameters as? CardanoFeeParameters else {
             return nil
         }
+
+        let value = Decimal(parameters.adaValue).moveLeft(decimals: wallet.blockchain.decimalCount)
+        let amount = Amount(with: wallet.blockchain, value: value)
+        return .cardanoWillBeSendAlongToken(amount: amount)
     }
 }
 
 // MARK: - CardanoTransferRestrictable
 
 extension CardanoWalletManager: CardanoTransferRestrictable {
-    func validateCardanoTransfer(amount: Amount, fee: Amount) throws {
+    func validateCardanoTransfer(amount: Amount, fee: Fee) throws {
         switch amount.type {
         case .coin:
             let hasTokensWithBalance = try transactionBuilder.hasTokensWithBalance(exclude: nil)
@@ -178,26 +175,28 @@ extension CardanoWalletManager: CardanoTransferRestrictable {
         }
     }
 
-    private func validateCardanoCoinWithdrawal(amount: Amount, fee: Amount) throws {
+    private func validateCardanoCoinWithdrawal(amount: Amount, fee: Fee) throws {
         assert(!amount.type.isToken, "Only coin validation")
 
         guard let adaBalance = wallet.amounts[.coin]?.value else {
             throw ValidationError.balanceNotFound
         }
 
-        let minChange = try minChange(amount: amount)
-        var change = adaBalance - amount.value
-
-        if amount.type == fee.type {
-            change -= fee.value
+        guard let parameters = fee.parameters as? CardanoFeeParameters else {
+            throw CardanoTransactionBuilderError.feeParametersNotFound
         }
 
-        if change < minChange.value {
-            throw ValidationError.cardanoHasTokens(minimumAmount: minChange)
+        let minChange = try transactionBuilder.minChange(amount: amount)
+
+        if parameters.change < minChange {
+            let minChangeDecimal = Decimal(minChange) / wallet.blockchain.decimalValue
+            let minimumAmount = Amount(with: wallet.blockchain, value: minChangeDecimal)
+
+            throw ValidationError.cardanoHasTokens(minimumAmount: minimumAmount)
         }
     }
 
-    private func validateCardanoTokenWithdrawal(amount: Amount, fee: Amount) throws {
+    private func validateCardanoTokenWithdrawal(amount: Amount, fee: Fee) throws {
         assert(amount.type.isToken, "Only token validation")
 
         guard var adaBalance = wallet.amounts[.coin]?.value else {
@@ -209,35 +208,30 @@ extension CardanoWalletManager: CardanoTransferRestrictable {
         }
 
         // the fee will be spend in any case
-        adaBalance -= fee.value
-        
+        adaBalance -= fee.amount.value
+
         // 1. Check if there is enough ADA to send the token
-        let minAdaValue = try transactionBuilder.buildCardanoSpendingAdaValue(amount: amount, fee: fee)
-        let minAdaToSendDecimal = Decimal(minAdaValue) / wallet.blockchain.decimalValue
+        guard let parameters = fee.parameters as? CardanoFeeParameters else {
+            throw CardanoTransactionBuilderError.feeParametersNotFound
+        }
+
+        let sendingAdaValueDecimal = Decimal(parameters.adaValue) / wallet.blockchain.decimalValue
 
         // Not enough balance to send token
-        if minAdaToSendDecimal > adaBalance {
+        if sendingAdaValueDecimal > adaBalance {
             throw ValidationError.cardanoInsufficientBalanceToSendToken
         }
 
         // 2. Check if there is enough ADA to get a change with after transaction
-        let minChange = try minChange(amount: amount)
-        let change = adaBalance - minAdaToSendDecimal
-
+        let minChange = try transactionBuilder.minChange(amount: amount)
         let isSendFullTokenAmount = amount.value == tokenBalance
         let willReceiveChange = try transactionBuilder.hasTokensWithBalance(
             exclude: isSendFullTokenAmount ? amount.type.token : nil
         )
 
         // If there not enough ada balance to change
-        if willReceiveChange, change < minChange.value {
+        if willReceiveChange, parameters.change < minChange {
             throw ValidationError.cardanoInsufficientBalanceToSendToken
         }
-    }
-
-    private func minChange(amount: Amount) throws -> Amount {
-        let minChangeValue = try transactionBuilder.minChange(amount: amount)
-        let minChangeDecimal = Decimal(minChangeValue) / wallet.blockchain.decimalValue
-        return Amount(with: wallet.blockchain, value: minChangeDecimal)
     }
 }

--- a/BlockchainSdk/Blockchains/Chia/ChiaWalletManager.swift
+++ b/BlockchainSdk/Blockchains/Chia/ChiaWalletManager.swift
@@ -150,7 +150,7 @@ extension ChiaWalletManager: WithdrawalNotificationProvider {
         )
     }
 
-    func withdrawalNotification(amount: Amount, fee: Amount) -> WithdrawalNotification? {
+    func withdrawalNotification(amount: Amount, fee: Fee) -> WithdrawalNotification? {
         // The 'Mandatory amount change' withdrawal suggestion has been superseded by a validation performed in
         // the 'MaximumAmountRestrictable.validateMaximumAmount(amount:fee:)' method below
         return nil

--- a/BlockchainSdk/Blockchains/Kaspa/KaspaWalletManager.swift
+++ b/BlockchainSdk/Blockchains/Kaspa/KaspaWalletManager.swift
@@ -125,7 +125,7 @@ extension KaspaWalletManager: WithdrawalNotificationProvider {
         )
     }
     
-    func withdrawalNotification(amount: Amount, fee: Amount) -> WithdrawalNotification? {
+    func withdrawalNotification(amount: Amount, fee: Fee) -> WithdrawalNotification? {
         // The 'Mandatory amount change' withdrawal suggestion has been superseded by a validation performed in
         // the 'MaximumAmountRestrictable.validateMaximumAmount(amount:fee:)' method below
         return nil

--- a/BlockchainSdk/Blockchains/Tezos/TezosWalletManager.swift
+++ b/BlockchainSdk/Blockchains/Tezos/TezosWalletManager.swift
@@ -168,10 +168,10 @@ extension TezosWalletManager: WithdrawalNotificationProvider {
         return nil
     }
     
-    func withdrawalNotification(amount: Amount, fee: Amount) -> WithdrawalNotification? {
+    func withdrawalNotification(amount: Amount, fee: Fee) -> WithdrawalNotification? {
         guard
             let walletAmount = wallet.amounts[.coin],
-            amount + fee == walletAmount 
+            amount + fee.amount == walletAmount
         else {
             return nil
         }

--- a/BlockchainSdk/Common/Interfaces/BlockchainNotifications/WithdrawalSuggestionProvider.swift
+++ b/BlockchainSdk/Common/Interfaces/BlockchainNotifications/WithdrawalSuggestionProvider.swift
@@ -12,7 +12,7 @@ public protocol WithdrawalNotificationProvider {
     @available(*, deprecated, message: "Use WithdrawalNotificationProvider.withdrawalSuggestion")
     func validateWithdrawalWarning(amount: Amount, fee: Amount) -> WithdrawalWarning?
     
-    func withdrawalNotification(amount: Amount, fee: Amount) -> WithdrawalNotification?
+    func withdrawalNotification(amount: Amount, fee: Fee) -> WithdrawalNotification?
 }
 
 @available(*, deprecated, message: "Use WithdrawalNotificationProvider.withdrawalSuggestion")

--- a/BlockchainSdk/Common/Interfaces/TransactionValidator/CardanoTransferRestrictable.swift
+++ b/BlockchainSdk/Common/Interfaces/TransactionValidator/CardanoTransferRestrictable.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 protocol CardanoTransferRestrictable {
-    func validateCardanoTransfer(amount: Amount, fee: Amount) throws
+    func validateCardanoTransfer(amount: Amount, fee: Fee) throws
 }

--- a/BlockchainSdk/Common/Interfaces/TransactionValidator/TransactionValidator.swift
+++ b/BlockchainSdk/Common/Interfaces/TransactionValidator/TransactionValidator.swift
@@ -165,7 +165,7 @@ extension TransactionValidator where Self: DustRestrictable, Self: CardanoTransf
 
     func validate(amount: Amount, fee: Fee) throws {
         try validateAmounts(amount: amount, fee: fee.amount)
-        try validateCardanoTransfer(amount: amount, fee: fee.amount)
+        try validateCardanoTransfer(amount: amount, fee: fee)
         try validateDust(amount: amount, fee: fee.amount)
     }
 }

--- a/BlockchainSdkTests/Cardano/CardanoTests.swift
+++ b/BlockchainSdkTests/Cardano/CardanoTests.swift
@@ -25,14 +25,6 @@ class CardanoTests: XCTestCase {
     // Successful transaction
     // https://cardanoscan.io/transaction/db2306d819d848f67f70ab898028d9827e5d1fccc7033531534fdd39e93a796e
     func testSignTransfer() throws {
-        let transaction = Transaction(
-            amount: Amount(with: blockchain, value: 1.8),
-            fee: Fee(.zeroCoin(for: blockchain)),
-            sourceAddress: "addr1vyn6tvyc3daxl8wwvm2glay287dfa7xjgdm2jdl308ksy9canqafn",
-            destinationAddress: "addr1q90uh2eawrdc9vaemftgd50l28yrh9lqxtjjh4z6dnn0u7ggasexxdyyk9f05atygnjlccsjsggtc87hhqjna32fpv5qeq96ls",
-            changeAddress: "addr1vyn6tvyc3daxl8wwvm2glay287dfa7xjgdm2jdl308ksy9canqafn"
-        )
-        
         let utxos = [
             CardanoUnspentOutput(address: "addr1vyn6tvyc3daxl8wwvm2glay287dfa7xjgdm2jdl308ksy9canqafn",
                                  amount: 2500000,
@@ -47,6 +39,22 @@ class CardanoTests: XCTestCase {
         ]
 
         transactionBuilder.update(outputs: utxos)
+
+        let (_, parameters) = try transactionBuilder.getFee(
+            amount: Amount(with: blockchain, value: 1.8),
+            destination: "Ae2tdPwUPEZ4kps4As3f38H3gyjMs2YoMdJVMCq3UQzK4zhLunRriZpfbhs",
+            source: "addr1vyn6tvyc3daxl8wwvm2glay287dfa7xjgdm2jdl308ksy9canqafn"
+        )
+
+        let transaction = Transaction(
+            amount: Amount(with: blockchain, value: 1.8),
+            fee: Fee(.zeroCoin(for: blockchain), parameters: parameters), // parameters is manandatory
+            sourceAddress: "addr1vyn6tvyc3daxl8wwvm2glay287dfa7xjgdm2jdl308ksy9canqafn",
+            destinationAddress: "addr1q90uh2eawrdc9vaemftgd50l28yrh9lqxtjjh4z6dnn0u7ggasexxdyyk9f05atygnjlccsjsggtc87hhqjna32fpv5qeq96ls",
+            changeAddress: "addr1vyn6tvyc3daxl8wwvm2glay287dfa7xjgdm2jdl308ksy9canqafn"
+        )
+        
+
         
         let dataForSign = try transactionBuilder.buildForSign(transaction: transaction)
         XCTAssertEqual(
@@ -69,14 +77,6 @@ class CardanoTests: XCTestCase {
     // Successful transaction
     // https://cardanoscan.io/transaction/03946fe122634d05e93219fde628ce55a5e0d06f23afa456864897357c5dade8
     func testSignTransferFromLegacy() throws {
-        let transaction = Transaction(
-            amount: Amount(with: blockchain, value: 1.3),
-            fee: Fee(.zeroCoin(for: blockchain)),
-            sourceAddress: "addr1vyn6tvyc3daxl8wwvm2glay287dfa7xjgdm2jdl308ksy9canqafn",
-            destinationAddress: "Ae2tdPwUPEZ4kps4As3f38H3gyjMs2YoMdJVMCq3UQzK4zhLunRriZpfbhs",
-            changeAddress: "addr1vyn6tvyc3daxl8wwvm2glay287dfa7xjgdm2jdl308ksy9canqafn"
-        )
-        
         let utxos = [
             CardanoUnspentOutput(address: "addr1vyn6tvyc3daxl8wwvm2glay287dfa7xjgdm2jdl308ksy9canqafn",
                                  amount: 1981037,
@@ -89,8 +89,23 @@ class CardanoTests: XCTestCase {
                                  transactionHash: "848c0861a3dc02a806d71cb35de83ffbc2a8553d161e2449c37572d7c2de44a7",
                                  assets: []),
         ]
-        
+
         transactionBuilder.update(outputs: utxos)
+
+        let (_, parameters) = try transactionBuilder.getFee(
+            amount: Amount(with: blockchain, value: 1.3),
+            destination: "Ae2tdPwUPEZ4kps4As3f38H3gyjMs2YoMdJVMCq3UQzK4zhLunRriZpfbhs",
+            source: "addr1vyn6tvyc3daxl8wwvm2glay287dfa7xjgdm2jdl308ksy9canqafn"
+        )
+
+        let transaction = Transaction(
+            amount: Amount(with: blockchain, value: 1.3),
+            fee: Fee(.zeroCoin(for: blockchain), parameters: parameters), // parameters is manandatory
+            sourceAddress: "addr1vyn6tvyc3daxl8wwvm2glay287dfa7xjgdm2jdl308ksy9canqafn",
+            destinationAddress: "Ae2tdPwUPEZ4kps4As3f38H3gyjMs2YoMdJVMCq3UQzK4zhLunRriZpfbhs",
+            changeAddress: "addr1vyn6tvyc3daxl8wwvm2glay287dfa7xjgdm2jdl308ksy9canqafn"
+        )
+
         let dataForSign = try transactionBuilder.buildForSign(transaction: transaction)
         XCTAssertEqual(dataForSign.hexString.lowercased(), "03946fe122634d05e93219fde628ce55a5e0d06f23afa456864897357c5dade8")
 
@@ -110,21 +125,6 @@ class CardanoTests: XCTestCase {
     // Successful transaction
     // https://cardanoscan.io/transaction/3ac6b76c63e109494823fe13e6f6d52544896a5ab81ae711ce56f039d6777bd1
     func testSignTransferToken() throws {
-        let token = Token(
-            name: "SingularityNET",
-            symbol: "AGIX",
-            contractAddress: "asset1wwyy88f8u937hz7kunlkss7gu446p6ed5gdfp6",
-            decimalCount: 8
-        )
-        
-        let transaction = Transaction(
-            amount: Amount(with: blockchain, type: .token(value: token), value: 0.65),
-            fee: Fee(.zeroCoin(for: blockchain)), // Will not be used
-            sourceAddress: "addr1vyn6tvyc3daxl8wwvm2glay287dfa7xjgdm2jdl308ksy9canqafn",
-            destinationAddress: "addr1qx55ymlqemndq8gluv40v58pu76a2tp4mzjnyx8n6zrp2vtzrs43a0057y0edkn8lh9su8vh5lnhs4npv6l9tuvncv8swc7t08",
-            changeAddress: "addr1vyn6tvyc3daxl8wwvm2glay287dfa7xjgdm2jdl308ksy9canqafn"
-        )
-        
         let utxos = [
             CardanoUnspentOutput(address: "addr1vyn6tvyc3daxl8wwvm2glay287dfa7xjgdm2jdl308ksy9canqafn",
                                  amount: 1796085,
@@ -159,8 +159,30 @@ class CardanoTests: XCTestCase {
                                     )
                                  ]),
         ]
-        
+
         transactionBuilder.update(outputs: utxos)
+        
+        let token = Token(
+            name: "SingularityNET",
+            symbol: "AGIX",
+            contractAddress: "asset1wwyy88f8u937hz7kunlkss7gu446p6ed5gdfp6",
+            decimalCount: 8
+        )
+
+        let (_, parameters) = try transactionBuilder.getFee(
+            amount: Amount(with: blockchain, type: .token(value: token), value: 0.65),
+            destination: "addr1qx55ymlqemndq8gluv40v58pu76a2tp4mzjnyx8n6zrp2vtzrs43a0057y0edkn8lh9su8vh5lnhs4npv6l9tuvncv8swc7t08",
+            source: "addr1vyn6tvyc3daxl8wwvm2glay287dfa7xjgdm2jdl308ksy9canqafn"
+        )
+
+        let transaction = Transaction(
+            amount: Amount(with: blockchain, type: .token(value: token), value: 0.65),
+            fee: Fee(.zeroCoin(for: blockchain), parameters: parameters), // parameters is manandatory
+            sourceAddress: "addr1vyn6tvyc3daxl8wwvm2glay287dfa7xjgdm2jdl308ksy9canqafn",
+            destinationAddress: "addr1qx55ymlqemndq8gluv40v58pu76a2tp4mzjnyx8n6zrp2vtzrs43a0057y0edkn8lh9su8vh5lnhs4npv6l9tuvncv8swc7t08",
+            changeAddress: "addr1vyn6tvyc3daxl8wwvm2glay287dfa7xjgdm2jdl308ksy9canqafn"
+        )
+
         let dataForSign = try transactionBuilder.buildForSign(transaction: transaction)
         XCTAssertEqual(dataForSign.hexString.lowercased(), "3ac6b76c63e109494823fe13e6f6d52544896a5ab81ae711ce56f039d6777bd1")
 
@@ -178,14 +200,6 @@ class CardanoTests: XCTestCase {
     }
     
     func testSignTransferExtendedKey() throws {
-        let transaction = Transaction(
-            amount: Amount(with: blockchain, value: 7),
-            fee: Fee(.zeroCoin(for: blockchain)),
-            sourceAddress: "addr1q8043m5heeaydnvtmmkyuhe6qv5havvhsf0d26q3jygsspxlyfpyk6yqkw0yhtyvtr0flekj84u64az82cufmqn65zdsylzk23",
-            destinationAddress: "addr1q92cmkgzv9h4e5q7mnrzsuxtgayvg4qr7y3gyx97ukmz3dfx7r9fu73vqn25377ke6r0xk97zw07dqr9y5myxlgadl2s0dgke5",
-            changeAddress: "addr1q8043m5heeaydnvtmmkyuhe6qv5havvhsf0d26q3jygsspxlyfpyk6yqkw0yhtyvtr0flekj84u64az82cufmqn65zdsylzk23"
-        )
-        
         let utxos = [
             CardanoUnspentOutput(address: "addr1q8043m5heeaydnvtmmkyuhe6qv5havvhsf0d26q3jygsspxlyfpyk6yqkw0yhtyvtr0flekj84u64az82cufmqn65zdsylzk23",
                                  amount: 1500000,
@@ -200,6 +214,21 @@ class CardanoTests: XCTestCase {
         ]
 
         transactionBuilder.update(outputs: utxos)
+
+        let (_, parameters) = try transactionBuilder.getFee(
+            amount: Amount(with: blockchain, value: 7),
+            destination: "addr1q92cmkgzv9h4e5q7mnrzsuxtgayvg4qr7y3gyx97ukmz3dfx7r9fu73vqn25377ke6r0xk97zw07dqr9y5myxlgadl2s0dgke5",
+            source: "addr1q8043m5heeaydnvtmmkyuhe6qv5havvhsf0d26q3jygsspxlyfpyk6yqkw0yhtyvtr0flekj84u64az82cufmqn65zdsylzk23"
+        )
+
+        let transaction = Transaction(
+            amount: Amount(with: blockchain, value: 7),
+            fee: Fee(.zeroCoin(for: blockchain), parameters: parameters), // parameters is manandatory
+            sourceAddress: "addr1q8043m5heeaydnvtmmkyuhe6qv5havvhsf0d26q3jygsspxlyfpyk6yqkw0yhtyvtr0flekj84u64az82cufmqn65zdsylzk23",
+            destinationAddress: "addr1q92cmkgzv9h4e5q7mnrzsuxtgayvg4qr7y3gyx97ukmz3dfx7r9fu73vqn25377ke6r0xk97zw07dqr9y5myxlgadl2s0dgke5",
+            changeAddress: "addr1q8043m5heeaydnvtmmkyuhe6qv5havvhsf0d26q3jygsspxlyfpyk6yqkw0yhtyvtr0flekj84u64az82cufmqn65zdsylzk23"
+        )
+
         let dataForSign = try transactionBuilder.buildForSign(transaction: transaction)
         XCTAssertEqual(
             dataForSign.hexString.lowercased(),

--- a/BlockchainSdkTests/Cardano/CardanoTests.swift
+++ b/BlockchainSdkTests/Cardano/CardanoTests.swift
@@ -42,7 +42,7 @@ class CardanoTests: XCTestCase {
 
         let (_, parameters) = try transactionBuilder.getFee(
             amount: Amount(with: blockchain, value: 1.8),
-            destination: "Ae2tdPwUPEZ4kps4As3f38H3gyjMs2YoMdJVMCq3UQzK4zhLunRriZpfbhs",
+            destination: "addr1q90uh2eawrdc9vaemftgd50l28yrh9lqxtjjh4z6dnn0u7ggasexxdyyk9f05atygnjlccsjsggtc87hhqjna32fpv5qeq96ls",
             source: "addr1vyn6tvyc3daxl8wwvm2glay287dfa7xjgdm2jdl308ksy9canqafn"
         )
 


### PR DESCRIPTION
- Упростил код
- Используем WalletCore для вычисления сдачи/fee
- Добавлен `CardanoFeeParameters` для того что бы расчеты были только в одном месте и один раз

Проверил кейсы:
- Полный/не полный вывод ADA
- Полный/не полный вывод ADA с токеном
- Полный/не полный вывод ADA с несколькими токенами
- Полный/не полный вывод Токена с ADA > 5
- Полный/не полный вывод Токена с ADA = 1.51 (minValue + not enough for fee)
- Полный/не полный вывод Токена с ADA = 2.48 (minValue + not enough for change)
