### PR TITLE
IOS-7256: Fix multiple resuming of continuations in `URLSessionWebSocketTaskWrapper`

### DIFF
--- a/BlockchainSdk/Common/WebSocket/URLSessionWebSocketTaskWrapper.swift
+++ b/BlockchainSdk/Common/WebSocket/URLSessionWebSocketTaskWrapper.swift
@@ -129,10 +129,10 @@ private extension URLSessionWebSocketTaskWrapper {
     /// - The wrapped continuation never leaks (by leaving unresumed).
     final class CheckedContinuationWrapper<T, E> where E: Error {
         private var continuation: CheckedContinuation<T, E>?
-        private let fallback: Result<T, E>
+        private let fallback: () -> Result<T, E>
         private let criticalSection = Lock(isRecursive: false)
 
-        init(fallback: Result<T, E>) {
+        init(fallback: @autoclosure @escaping () -> Result<T, E>) {
             self.fallback = fallback
         }
 
@@ -142,7 +142,7 @@ private extension URLSessionWebSocketTaskWrapper {
 
         func set(_ newContinuation: CheckedContinuation<T, E>?) {
             criticalSection {
-                continuation?.resume(with: fallback)
+                continuation?.resume(with: fallback())
                 continuation = newContinuation
             }
         }

--- a/BlockchainSdk/Common/WebSocket/URLSessionWebSocketTaskWrapper.swift
+++ b/BlockchainSdk/Common/WebSocket/URLSessionWebSocketTaskWrapper.swift
@@ -12,8 +12,14 @@ import Foundation
 class URLSessionWebSocketTaskWrapper {
     private let url: URL
     
-    private var webSocketTaskDidOpen: CheckedContinuation<Void, any Error>?
-    private var webSocketTaskDidClose: CheckedContinuation<URLSessionWebSocketTask.CloseCode, Never>?
+    private let webSocketTaskDidOpen = CheckedContinuationWrapper<Void, Error>(
+        fallback: .failure(CancellationError())
+    )
+
+    private let webSocketTaskDidClose = CheckedContinuationWrapper<URLSessionWebSocketTask.CloseCode, Never>(
+        fallback: .success(.abnormalClosure)
+    )
+
     private var session: URLSession?
     private var _sessionWebSocketTask: URLSessionWebSocketTask?
 
@@ -62,16 +68,17 @@ class URLSessionWebSocketTaskWrapper {
     func connect() async throws {
         // The delegate will be kept by URLSession
         let delegate = URLSessionWebSocketDelegateWrapper(
-            webSocketTaskDidOpen: { [weak self] task in
-                self?.webSocketTaskDidOpen?.resume()
+            webSocketTaskDidOpen: { [weak self] _ in
+                self?.webSocketTaskDidOpen.resume(with: .success(()))
             },
-            webSocketTaskDidClose: { [weak self] task, closeCode in
-                self?.webSocketTaskDidClose?.resume(returning: closeCode)
-            }, webSocketTaskDidCompleteWithError: { [weak self] _, error in
+            webSocketTaskDidClose: { [weak self] _, closeCode in
+                self?.webSocketTaskDidClose.resume(with: .success(closeCode))
+            },
+            webSocketTaskDidCompleteWithError: { [weak self] _, error in
                 self?.cancel()
                 
                 if let error {
-                    self?.webSocketTaskDidOpen?.resume(throwing: error)
+                    self?.webSocketTaskDidOpen.resume(with: .failure(error))
                 }
             }
         )
@@ -81,7 +88,7 @@ class URLSessionWebSocketTaskWrapper {
         _sessionWebSocketTask?.resume()
 
         return try await withCheckedThrowingContinuation { [weak self] continuation in
-            self?.webSocketTaskDidOpen = continuation
+            self?.webSocketTaskDidOpen.set(continuation)
         }
     }
     
@@ -95,7 +102,7 @@ class URLSessionWebSocketTaskWrapper {
         _sessionWebSocketTask?.cancel(with: .goingAway, reason: nil)
         
         return await withCheckedContinuation { [weak self] continuation in
-            self?.webSocketTaskDidClose = continuation
+            self?.webSocketTaskDidClose.set(continuation)
         }
     }
 }
@@ -112,4 +119,39 @@ extension URLSessionWebSocketTaskWrapper: CustomStringConvertible {
 
 enum WebSocketTaskError: Error {
     case webSocketNotFound
+}
+
+// MARK: - Auxiliary types
+
+private extension URLSessionWebSocketTaskWrapper {
+    /// This lightweight wrapper ensures two things:
+    /// - The wrapped continuation is resumed only once.
+    /// - The wrapped continuation never leaks (by leaving unresumed).
+    final class CheckedContinuationWrapper<T, E> where E: Error {
+        private var continuation: CheckedContinuation<T, E>?
+        private let fallback: Result<T, E>
+        private let criticalSection = Lock(isRecursive: false)
+
+        init(fallback: Result<T, E>) {
+            self.fallback = fallback
+        }
+
+        deinit {
+            set(nil)
+        }
+
+        func set(_ newContinuation: CheckedContinuation<T, E>?) {
+            criticalSection {
+                continuation?.resume(with: fallback)
+                continuation = newContinuation
+            }
+        }
+
+        func resume(with result: Result<T, E>) {
+            criticalSection {
+                continuation?.resume(with: result)
+                continuation = nil
+            }
+        }
+    }
 }


### PR DESCRIPTION
[IOS-7256](https://tangem.atlassian.net/browse/IOS-7256)

Отдельный враппер так как тот, который добавлен в [IOS-7104](https://tangem.atlassian.net/browse/IOS-7104) - рассчитан на работу в async-await контекстах (ну и не имеет RAII семантики)

[IOS-7256]: https://tangem.atlassian.net/browse/IOS-7256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IOS-7104]: https://tangem.atlassian.net/browse/IOS-7104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ