### PR TITLE
IOS-7571: Fix duplicate entries in tx history

### DIFF
--- a/BlockchainSdk/Common/TransactionHistory/Algorand/AlgorandTransactionHistoryProvider.swift
+++ b/BlockchainSdk/Common/TransactionHistory/Algorand/AlgorandTransactionHistoryProvider.swift
@@ -47,7 +47,12 @@ extension AlgorandTransactionHistoryProvider: TransactionHistoryProvider {
     }
     
     var description: String {
-        return "nextToken: \(page?.next ?? "-")"
+        return objectDescription(
+            self,
+            userInfo: [
+                "nextToken": page?.next ?? "-",
+            ]
+        )
     }
     
     func reset() {

--- a/BlockchainSdk/Common/TransactionHistory/Ethereum/EthereumTransactionHistoryMapper.swift
+++ b/BlockchainSdk/Common/TransactionHistory/Ethereum/EthereumTransactionHistoryMapper.swift
@@ -279,10 +279,11 @@ private extension EthereumTransactionHistoryMapper {
     ) -> [TransactionRecord] {
         let hash = transaction.txid
         let fee = Fee(Amount(with: blockchain, value: feeValue / blockchain.decimalValue))
-        let index = transactionIndicesCounter[hash, default: 0]
-        transactionIndicesCounter[hash] = index + 1
 
         return transactionInfos.map { transactionInfo in
+            let index = transactionIndicesCounter[hash, default: 0]
+            transactionIndicesCounter[hash] = index + 1
+
             return TransactionRecord(
                 hash: hash,
                 index: index,

--- a/BlockchainSdk/Common/TransactionHistory/Ethereum/EthereumTransactionHistoryProvider.swift
+++ b/BlockchainSdk/Common/TransactionHistory/Ethereum/EthereumTransactionHistoryProvider.swift
@@ -37,7 +37,14 @@ extension EthereumTransactionHistoryProvider: TransactionHistoryProvider {
     }
     
     var description: String {
-        return "number: \(String(describing: page?.number)); \(totalPages); \(totalRecordsCount)"
+        return objectDescription(
+            self,
+            userInfo: [
+                "pageNumber": String(describing: page?.number),
+                "totalPages": totalPages,
+                "totalRecordsCount": totalRecordsCount,
+            ]
+        )
     }
     
     func reset() {

--- a/BlockchainSdk/Common/TransactionHistory/Tron/TronTransactionHistoryMapper.swift
+++ b/BlockchainSdk/Common/TransactionHistory/Tron/TronTransactionHistoryMapper.swift
@@ -157,10 +157,10 @@ final class TronTransactionHistoryMapper {
         let type = transactionType(transaction, amountType: amountType)
         let tokenTransfers = tokenTransfers(transaction)
 
-        let index = transactionIndicesCounter[hash, default: 0]
-        transactionIndicesCounter[hash] = index + 1
-
         return transactionInfos.map { transactionInfo in
+            let index = transactionIndicesCounter[hash, default: 0]
+            transactionIndicesCounter[hash] = index + 1
+
             return TransactionRecord(
                 hash: hash,
                 index: index,

--- a/BlockchainSdk/Common/TransactionHistory/UTXO/UTXOTransactionHistoryProvider.swift
+++ b/BlockchainSdk/Common/TransactionHistory/UTXO/UTXOTransactionHistoryProvider.swift
@@ -40,7 +40,14 @@ extension UTXOTransactionHistoryProvider: TransactionHistoryProvider {
     }
     
     var description: String {
-        return "number: \(String(describing: page?.number)); \(totalPages); \(totalRecordsCount)"
+        return objectDescription(
+            self,
+            userInfo: [
+                "pageNumber": String(describing: page?.number),
+                "totalPages": totalPages,
+                "totalRecordsCount": totalRecordsCount,
+            ]
+        )
     }
     
     func reset() {


### PR DESCRIPTION
[IOS-7571](https://tangem.atlassian.net/browse/IOS-7571)

Проблема была в некорректном маппинге (для EVM/Tron, Polygon юзает отдельный провайдер и там все ок) как раз того редкого кейса, для которого и добавлялась поддержка indexed txs - когда внутри одной транзакции есть более одного трансфера токенов
Пример такой транзакции - https://bscscan.com/tx/0x4e1fdcfadc2b502eecf5a3a75bdfa064f71155b334c6455cfe74342b927aa9dd

Два трансфера USDC с src 0x41D3De2898AFA126Fd70fF18caA96920cc31E8fd на разные адреса

<img width="881" alt="Screenshot 2024-08-07 at 22 17 53" src="https://github.com/user-attachments/assets/35bbe43d-6f81-4620-ac41-9f6b33d3c3f7">

В истории транз USDC они должны отобразиться как две транзакции


[IOS-7571]: https://tangem.atlassian.net/browse/IOS-7571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ