### PR TITLE
IOS-8050: Apply rounding to the Hedera fee value

### DIFF
--- a/BlockchainSdk/Blockchains/Hedera/HederaTransactionBuilder.swift
+++ b/BlockchainSdk/Blockchains/Hedera/HederaTransactionBuilder.swift
@@ -58,6 +58,8 @@ final class HederaTransactionBuilder {
     ) throws -> CompiledTransaction {
         // At the moment, we intentionally don't support custom fees for HTS tokens (HIP-18 https://hips.hedera.com/HIP/hip-18.html)
         let feeValue = transaction.fee.amount.value * pow(Decimal(10), transaction.fee.amount.decimals)
+        // Hedera fee calculation involves conversion from USD to HBar units, which ultimately results in a loss of precision.
+        // Therefore, the fee value is always approximate and rounding of the fee value is mandatory.
         let feeRoundedValue = feeValue.rounded(roundingMode: .up)
         let feeAmount = try Hbar(feeRoundedValue, .tinybar)
 

--- a/BlockchainSdk/Blockchains/Hedera/HederaWalletManager.swift
+++ b/BlockchainSdk/Blockchains/Hedera/HederaWalletManager.swift
@@ -422,7 +422,10 @@ final class HederaWalletManager: BaseManager {
             let (exchangeRate, doesAccountExist) = input
             let feeBase = doesAccountExist ? transferFeeBase : Constants.cryptoCreateServiceCostInUSD
             let feeValue = exchangeRate.nextHBARPerUSD * feeBase * Constants.maxFeeMultiplier
-            let feeAmount = Amount(with: walletManager.wallet.blockchain, value: feeValue)
+            // Hedera fee calculation involves conversion from USD to HBar units, which ultimately results in a loss of precision.
+            // Therefore, the fee value is always approximate and rounding of the fee value is mandatory.
+            let feeRoundedValue = feeValue.rounded(blockchain: walletManager.wallet.blockchain, roundingMode: .up)
+            let feeAmount = Amount(with: walletManager.wallet.blockchain, value: feeRoundedValue)
             let fee = Fee(feeAmount)
 
             return [fee]
@@ -553,7 +556,10 @@ extension HederaWalletManager: AssetRequirementsManager {
             }
 
             let feeValue = tokenAssociationFeeExchangeRate * Constants.tokenAssociateServiceCostInUSD
-            let feeAmount = Amount.init(with: wallet.blockchain, value: feeValue)
+            // Hedera fee calculation involves conversion from USD to HBar units, which ultimately results in a loss of precision.
+            // Therefore, the fee value is always approximate and rounding of the fee value is mandatory.
+            let feeRoundedValue = feeValue.rounded(blockchain: wallet.blockchain, roundingMode: .up)
+            let feeAmount = Amount(with: wallet.blockchain, value: feeRoundedValue)
 
             return .paidTransactionWithFee(feeAmount: feeAmount)
         }


### PR DESCRIPTION
[IOS-8050](https://tangem.atlassian.net/browse/IOS-8050)

В общем корневая причина проблемы - это то что у хедеры фии номинируются в USD.
И соответственно есть exchange rate usd/hbar

Использование этого exchange rate приводит к потери точности - поэтому добавил округление up

[IOS-8050]: https://tangem.atlassian.net/browse/IOS-8050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ