### PR TITLE
IOS-8199 Send: zero transaction is displayed in the Recent list

### DIFF
--- a/BlockchainSdk/Common/TransactionHistory/TransactionHistoryProvider.swift
+++ b/BlockchainSdk/Common/TransactionHistory/TransactionHistoryProvider.swift
@@ -20,6 +20,8 @@ public protocol TransactionHistoryProvider: CustomStringConvertible {
 public extension TransactionHistoryProvider {
     func shouldBeIncludedInHistory(amountType: Amount.AmountType, record: TransactionRecord) -> Bool {
         switch amountType {
+        case .coin where record.type == .transfer:
+            break
         case .coin, .reserve, .feeResource:
             return true
         case .token:


### PR DESCRIPTION
[IOS-8199](https://tangem.atlassian.net/browse/IOS-8199)

Этот PR является заменой изменений из [другого PR по этой задаче](https://github.com/tangem/tangem-app-ios/pull/4028)

### Идея следующая:
При просмотре истории транзакций на версии из текущего develop'а для адреса [0xE35F09B310479fFdC10Ff583349C1020295AfEcF](https://polygonscan.com/address/0xE35F09B310479fFdC10Ff583349C1020295AfEcF) в полигоне видим следующее:
В списке есть нулевые транзакции, в основном контракты, но также есть и [транзакция самому себе](https://polygonscan.com/tx/0x443246d62c1524c4cb84b6f42db552500f07192a58880f04e7de4c59aeee799d) (предпоследняя снизу на первом скрине), соответственно и на экране сенда свой же адрес отображается в списке Recent

<img src="https://github.com/user-attachments/assets/ab711219-4c79-4282-8210-1929162a3df8" width=300><img src="https://github.com/user-attachments/assets/95f778de-d842-4f43-b406-5ff373f70ef4" width=300>

<br/>

### По идее желаемое поведение - это продолжать отображать контракты, но скрыть транзакцию самому себе (как в списке истории транзакций, так и на экране сенда в recent).

То есть дополнительно проверяем coin, и если тип его записи - это трансфер, то обрабатываем так же как и токен.
В итоге, в истории из нулевых транзакций остаются только контракты, и соответственно на экране сенда в Recent нулей нет совсем

<img src="https://github.com/user-attachments/assets/f562f263-6148-4296-89a2-c0c909f1d6f0" width=300><img src="https://github.com/user-attachments/assets/3d82473f-612f-4db2-a13e-922c66974d71" width=300>

[IOS-8199]: https://tangem.atlassian.net/browse/IOS-8199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ