### PR TITLE
IOS-8265 Core/EWT EVM:  not the correct derivation path for AC01/AC02 cards

### DIFF
--- a/BlockchainSdk/Common/Derivations/DerivationConfigV1.swift
+++ b/BlockchainSdk/Common/Derivations/DerivationConfigV1.swift
@@ -137,7 +137,9 @@ public struct DerivationConfigV1: DerivationConfig {
             return "m/44'/784'/0'/0'/0'"
         case .filecoin:
             return "m/44'/461'/0'/0/0"
-        case .energyWebEVM, .energyWebX:
+        case .energyWebEVM:
+            return "m/44'/246'/0'/0/0"
+        case .energyWebX:
             return "m/44'/246'/0'/0'/0'"
         case .core:
             return "m/44'/1116'/0'/0/0"


### PR DESCRIPTION
[IOS-8265](https://tangem.atlassian.net/browse/IOS-8265)

[Обсуждение здесь](https://tangem.slack.com/archives/C02KLRV4D97/p1728920596286509?thread_ts=1728913750.177499&cid=C02KLRV4D97)

Из обсуждения
`"m/44'/1116'/0'/0/0"`  core
`"m/44'/246'/0'/0/0"`   energy web evm
`"m/44'/246'/0'/0'/0'"` energy web x

[IOS-8265]: https://tangem.atlassian.net/browse/IOS-8265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ